### PR TITLE
Remove js extension from "types" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.2.1",
 	"description": "Configure Gatsby to use Typescript configuration files",
 	"main": "./index.js",
-	"types": "./dist/index.js",
+	"types": "./dist/index",
 	"author": "Jeremy Albright",
 	"license": "MIT",
 	"keywords": [


### PR DESCRIPTION
I found that my IDE (WebStorm) was not correctly finding the types for the package. It looks like it was due to the `types` pointing to a JS file. I believe that If you remove the extension, then the `.d.ts` is inferred. 

Thanks for the awesome package!