### PR TITLE
Custom plugin resolver

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -58,7 +58,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/typescript-estree", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.21.0"],
             ["@yarnpkg/pnpify", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.0.0-rc.18"],
             ["babel-plugin-dynamic-import-node", "npm:2.3.3"],
-            ["babel-preset-gatsby-package", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.4"],
             ["eslint", "npm:6.8.0"],
             ["fs-extra", "npm:8.1.0"],
             ["gatsby", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.19.23"],
@@ -280,13 +279,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/helper-compilation-targets", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.2", {
-          "packageLocation": "./.yarn/$$virtual/@babel-helper-compilation-targets-virtual-b1aca4c805/4/.yarncache/berry/cache/@babel-helper-compilation-targets-npm-7.10.2-3e629ecddc-2.zip/node_modules/@babel/helper-compilation-targets/",
+        ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.6", {
+          "packageLocation": "./.yarn/$$virtual/@babel-helper-compilation-targets-virtual-7d75a25ac8/4/.yarncache/berry/cache/@babel-helper-compilation-targets-npm-7.8.6-b7aee91f41-2.zip/node_modules/@babel/helper-compilation-targets/",
           "packageDependencies": [
-            ["@babel/helper-compilation-targets", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.2"],
-            ["@babel/compat-data", "npm:7.10.1"],
+            ["@babel/helper-compilation-targets", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.6"],
+            ["@babel/compat-data", "npm:7.8.6"],
             ["@babel/core", "npm:7.8.6"],
-            ["browserslist", "npm:4.12.0"],
+            ["browserslist", "npm:4.9.0"],
             ["invariant", "npm:2.2.4"],
             ["levenary", "npm:1.1.1"],
             ["semver", "npm:5.7.1"]
@@ -296,13 +295,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.6", {
-          "packageLocation": "./.yarn/$$virtual/@babel-helper-compilation-targets-virtual-7d75a25ac8/4/.yarncache/berry/cache/@babel-helper-compilation-targets-npm-7.8.6-b7aee91f41-2.zip/node_modules/@babel/helper-compilation-targets/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.2", {
+          "packageLocation": "./.yarn/$$virtual/@babel-helper-compilation-targets-virtual-60386ceb90/4/.yarncache/berry/cache/@babel-helper-compilation-targets-npm-7.10.2-3e629ecddc-2.zip/node_modules/@babel/helper-compilation-targets/",
           "packageDependencies": [
-            ["@babel/helper-compilation-targets", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.6"],
-            ["@babel/compat-data", "npm:7.8.6"],
+            ["@babel/helper-compilation-targets", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.2"],
+            ["@babel/compat-data", "npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["browserslist", "npm:4.9.0"],
+            ["browserslist", "npm:4.12.0"],
             ["invariant", "npm:2.2.4"],
             ["levenary", "npm:1.1.1"],
             ["semver", "npm:5.7.1"]
@@ -331,10 +330,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.2", {
-          "packageLocation": "./.yarn/$$virtual/@babel-helper-create-class-features-plugin-virtual-400dfc4c72/4/.yarncache/berry/cache/@babel-helper-create-class-features-plugin-npm-7.10.2-2c4050ffa6-2.zip/node_modules/@babel/helper-create-class-features-plugin/",
+        ["virtual:77bb6fe4c36ca148778627d74836622e4a1d08d1af7f096c0e34c7177a510195b1a44234d01cfc075bb26b611839524c5c4115d5a5b6d99858f927ca8e310a32#npm:7.10.2", {
+          "packageLocation": "./.yarn/$$virtual/@babel-helper-create-class-features-plugin-virtual-67228a7f6e/4/.yarncache/berry/cache/@babel-helper-create-class-features-plugin-npm-7.10.2-2c4050ffa6-2.zip/node_modules/@babel/helper-create-class-features-plugin/",
           "packageDependencies": [
-            ["@babel/helper-create-class-features-plugin", "virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.2"],
+            ["@babel/helper-create-class-features-plugin", "virtual:77bb6fe4c36ca148778627d74836622e4a1d08d1af7f096c0e34c7177a510195b1a44234d01cfc075bb26b611839524c5c4115d5a5b6d99858f927ca8e310a32#npm:7.10.2"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-function-name", "npm:7.10.1"],
             ["@babel/helper-member-expression-to-functions", "npm:7.10.1"],
@@ -384,10 +383,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/helper-create-regexp-features-plugin", [
-        ["virtual:1120c66e38adff9979f67f86ce6b7edd627879c20f265b980ac89f877f836fb4605ec49465b7034da6a10dad2fdd19c2868176e1945a9635a3c5f9b32d8260f2#npm:7.8.6", {
-          "packageLocation": "./.yarn/$$virtual/@babel-helper-create-regexp-features-plugin-virtual-c508863339/4/.yarncache/berry/cache/@babel-helper-create-regexp-features-plugin-npm-7.8.6-4be0355437-2.zip/node_modules/@babel/helper-create-regexp-features-plugin/",
+        ["virtual:50f975f857a68e232fbc6167e59f798f4a64bd215d8b552a504d648c0809ed1865be1b4a48c22744bd4155c762e609c9d6bba183b4b5d9b975223210398208ba#npm:7.8.6", {
+          "packageLocation": "./.yarn/$$virtual/@babel-helper-create-regexp-features-plugin-virtual-5dae389792/4/.yarncache/berry/cache/@babel-helper-create-regexp-features-plugin-npm-7.8.6-4be0355437-2.zip/node_modules/@babel/helper-create-regexp-features-plugin/",
           "packageDependencies": [
-            ["@babel/helper-create-regexp-features-plugin", "virtual:1120c66e38adff9979f67f86ce6b7edd627879c20f265b980ac89f877f836fb4605ec49465b7034da6a10dad2fdd19c2868176e1945a9635a3c5f9b32d8260f2#npm:7.8.6"],
+            ["@babel/helper-create-regexp-features-plugin", "virtual:50f975f857a68e232fbc6167e59f798f4a64bd215d8b552a504d648c0809ed1865be1b4a48c22744bd4155c762e609c9d6bba183b4b5d9b975223210398208ba#npm:7.8.6"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-annotate-as-pure", "npm:7.8.3"],
             ["@babel/helper-regex", "npm:7.8.3"],
@@ -412,10 +411,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:9c49dc8da71cec43a660f2958f0f1f311bb7662b7e19e7f70a1586dea8e1f156be228a1872e8d06ed1d2d7fc5051cd177bb87f2c11fd580e56b70bfdd18cde77#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-helper-create-regexp-features-plugin-virtual-f45ba2b4d5/4/.yarncache/berry/cache/@babel-helper-create-regexp-features-plugin-npm-7.10.1-9a2936330d-2.zip/node_modules/@babel/helper-create-regexp-features-plugin/",
+        ["virtual:cb8f80b61844cfdb1368d4bef351f30e068e6bd6d28b5a6ae078016a4ca8ce939c7f9c144ed8da631f977730ffe43f4be84ec10ceda87dd1b380ed16e0eedb05#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-helper-create-regexp-features-plugin-virtual-0ddf6a18c9/4/.yarncache/berry/cache/@babel-helper-create-regexp-features-plugin-npm-7.10.1-9a2936330d-2.zip/node_modules/@babel/helper-create-regexp-features-plugin/",
           "packageDependencies": [
-            ["@babel/helper-create-regexp-features-plugin", "virtual:9c49dc8da71cec43a660f2958f0f1f311bb7662b7e19e7f70a1586dea8e1f156be228a1872e8d06ed1d2d7fc5051cd177bb87f2c11fd580e56b70bfdd18cde77#npm:7.10.1"],
+            ["@babel/helper-create-regexp-features-plugin", "virtual:cb8f80b61844cfdb1368d4bef351f30e068e6bd6d28b5a6ae078016a4ca8ce939c7f9c144ed8da631f977730ffe43f4be84ec10ceda87dd1b380ed16e0eedb05#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-annotate-as-pure", "npm:7.10.1"],
             ["@babel/helper-regex", "npm:7.10.1"],
@@ -428,16 +427,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/helper-define-map", [
-        ["npm:7.10.1", {
-          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-define-map-npm-7.10.1-eb2889adbf-2.zip/node_modules/@babel/helper-define-map/",
-          "packageDependencies": [
-            ["@babel/helper-define-map", "npm:7.10.1"],
-            ["@babel/helper-function-name", "npm:7.10.1"],
-            ["@babel/types", "npm:7.10.2"],
-            ["lodash", "npm:4.17.15"]
-          ],
-          "linkType": "HARD",
-        }],
         ["npm:7.10.3", {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-define-map-npm-7.10.3-3b7c7666e5-2.zip/node_modules/@babel/helper-define-map/",
           "packageDependencies": [
@@ -538,14 +527,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/helper-hoist-variables", [
-        ["npm:7.10.1", {
-          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-hoist-variables-npm-7.10.1-55a26013e6-2.zip/node_modules/@babel/helper-hoist-variables/",
-          "packageDependencies": [
-            ["@babel/helper-hoist-variables", "npm:7.10.1"],
-            ["@babel/types", "npm:7.10.2"]
-          ],
-          "linkType": "HARD",
-        }],
         ["npm:7.10.3", {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-hoist-variables-npm-7.10.3-3f418a8829-2.zip/node_modules/@babel/helper-hoist-variables/",
           "packageDependencies": [
@@ -920,20 +901,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-proposal-async-generator-functions", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-async-generator-functions-virtual-f9f625fc65/4/.yarncache/berry/cache/@babel-plugin-proposal-async-generator-functions-npm-7.10.1-f64a5867fa-2.zip/node_modules/@babel/plugin-proposal-async-generator-functions/",
-          "packageDependencies": [
-            ["@babel/plugin-proposal-async-generator-functions", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/helper-remap-async-to-generator", "npm:7.10.1"],
-            ["@babel/plugin-syntax-async-generators", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.4"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-async-generator-functions-virtual-c32606f24d/4/.yarncache/berry/cache/@babel-plugin-proposal-async-generator-functions-npm-7.8.3-469aebfb21-2.zip/node_modules/@babel/plugin-proposal-async-generator-functions/",
           "packageDependencies": [
@@ -955,7 +922,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.3"],
             ["@babel/helper-remap-async-to-generator", "npm:7.10.3"],
-            ["@babel/plugin-syntax-async-generators", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.4"]
+            ["@babel/plugin-syntax-async-generators", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.4"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -977,12 +944,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-class-properties-virtual-468fd4605b/4/.yarncache/berry/cache/@babel-plugin-proposal-class-properties-npm-7.10.1-abd9523568-2.zip/node_modules/@babel/plugin-proposal-class-properties/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-class-properties-virtual-77bb6fe4c3/4/.yarncache/berry/cache/@babel-plugin-proposal-class-properties-npm-7.10.1-abd9523568-2.zip/node_modules/@babel/plugin-proposal-class-properties/",
           "packageDependencies": [
-            ["@babel/plugin-proposal-class-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-class-properties", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-create-class-features-plugin", "virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.2"],
+            ["@babel/helper-create-class-features-plugin", "virtual:77bb6fe4c36ca148778627d74836622e4a1d08d1af7f096c0e34c7177a510195b1a44234d01cfc075bb26b611839524c5c4115d5a5b6d99858f927ca8e310a32#npm:7.10.2"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
@@ -992,19 +959,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-proposal-dynamic-import", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-dynamic-import-virtual-62b21a264b/4/.yarncache/berry/cache/@babel-plugin-proposal-dynamic-import-npm-7.10.1-2d7fce232c-2.zip/node_modules/@babel/plugin-proposal-dynamic-import/",
-          "packageDependencies": [
-            ["@babel/plugin-proposal-dynamic-import", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-dynamic-import-virtual-027bd2c56d/4/.yarncache/berry/cache/@babel-plugin-proposal-dynamic-import-npm-7.8.3-17d98a1941-2.zip/node_modules/@babel/plugin-proposal-dynamic-import/",
           "packageDependencies": [
@@ -1017,22 +971,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-proposal-json-strings", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-json-strings-virtual-3765e00072/4/.yarncache/berry/cache/@babel-plugin-proposal-json-strings-npm-7.10.1-b718b5f017-2.zip/node_modules/@babel/plugin-proposal-json-strings/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-dynamic-import-virtual-dea8ade318/4/.yarncache/berry/cache/@babel-plugin-proposal-dynamic-import-npm-7.10.1-2d7fce232c-2.zip/node_modules/@babel/plugin-proposal-dynamic-import/",
           "packageDependencies": [
-            ["@babel/plugin-proposal-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-dynamic-import", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"]
+            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-proposal-json-strings", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-json-strings-virtual-bc5574b17b/4/.yarncache/berry/cache/@babel-plugin-proposal-json-strings-npm-7.8.3-52a77aa7a2-2.zip/node_modules/@babel/plugin-proposal-json-strings/",
           "packageDependencies": [
@@ -1040,6 +994,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"],
             ["@babel/plugin-syntax-json-strings", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-json-strings-virtual-18afd80302/4/.yarncache/berry/cache/@babel-plugin-proposal-json-strings-npm-7.10.1-b718b5f017-2.zip/node_modules/@babel/plugin-proposal-json-strings/",
+          "packageDependencies": [
+            ["@babel/plugin-proposal-json-strings", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"],
+            ["@babel/plugin-syntax-json-strings", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -1067,7 +1034,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:eed8eeef4910a2fcdb369cf67775b18fc345b7294b5ee2549a66416f0d97cd1003c839c34213098e4a5c3be0f62d7648e0f42f38c5636f9ee1c6be7865f11c6d#npm:7.8.3"]
+            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:6366cea8102b4b975891233f0336637b165f817687d86205582a902f3469fded79adf2e2cccd9f9d588e769df97dfc106b124470b2b96fef02858f93d3826038#npm:7.8.3"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -1076,13 +1043,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-proposal-numeric-separator", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-numeric-separator-virtual-c18a488ab4/4/.yarncache/berry/cache/@babel-plugin-proposal-numeric-separator-npm-7.10.1-7d7cf9ecbb-2.zip/node_modules/@babel/plugin-proposal-numeric-separator/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-numeric-separator-virtual-1fa1a35c78/4/.yarncache/berry/cache/@babel-plugin-proposal-numeric-separator-npm-7.10.1-7d7cf9ecbb-2.zip/node_modules/@babel/plugin-proposal-numeric-separator/",
           "packageDependencies": [
-            ["@babel/plugin-proposal-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-numeric-separator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"]
+            ["@babel/plugin-syntax-numeric-separator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -1091,20 +1058,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-proposal-object-rest-spread", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-object-rest-spread-virtual-73a3ee18d6/4/.yarncache/berry/cache/@babel-plugin-proposal-object-rest-spread-npm-7.10.1-3bb921cff7-2.zip/node_modules/@babel/plugin-proposal-object-rest-spread/",
-          "packageDependencies": [
-            ["@babel/plugin-proposal-object-rest-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-object-rest-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
-            ["@babel/plugin-transform-parameters", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-object-rest-spread-virtual-c1aa01a92e/4/.yarncache/berry/cache/@babel-plugin-proposal-object-rest-spread-npm-7.8.3-44ae847b64-2.zip/node_modules/@babel/plugin-proposal-object-rest-spread/",
           "packageDependencies": [
@@ -1124,8 +1077,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/plugin-proposal-object-rest-spread", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.3"],
-            ["@babel/plugin-syntax-object-rest-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
-            ["@babel/plugin-transform-parameters", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"]
+            ["@babel/plugin-syntax-object-rest-spread", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3"],
+            ["@babel/plugin-transform-parameters", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -1134,19 +1087,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-proposal-optional-catch-binding", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-optional-catch-binding-virtual-2b508c3da0/4/.yarncache/berry/cache/@babel-plugin-proposal-optional-catch-binding-npm-7.10.1-b4540464c0-2.zip/node_modules/@babel/plugin-proposal-optional-catch-binding/",
-          "packageDependencies": [
-            ["@babel/plugin-proposal-optional-catch-binding", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-optional-catch-binding", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-optional-catch-binding-virtual-e314c17ecc/4/.yarncache/berry/cache/@babel-plugin-proposal-optional-catch-binding-npm-7.8.3-9ea61a16bf-2.zip/node_modules/@babel/plugin-proposal-optional-catch-binding/",
           "packageDependencies": [
@@ -1159,22 +1099,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-proposal-optional-chaining", [
-        ["virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-optional-chaining-virtual-a84042cba7/4/.yarncache/berry/cache/@babel-plugin-proposal-optional-chaining-npm-7.10.1-6e1416319c-2.zip/node_modules/@babel/plugin-proposal-optional-chaining/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-optional-catch-binding-virtual-14e64e6024/4/.yarncache/berry/cache/@babel-plugin-proposal-optional-catch-binding-npm-7.10.1-b4540464c0-2.zip/node_modules/@babel/plugin-proposal-optional-catch-binding/",
           "packageDependencies": [
-            ["@babel/plugin-proposal-optional-chaining", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
+            ["@babel/plugin-proposal-optional-catch-binding", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-optional-chaining", "virtual:a84042cba769adb2e1a20888b5e698e93cdbacbd22d935dc93f12c2edae767e12e2ccb5fd7b839d2fdda56ac7f51361d3452737fd289b63ec372aefdb263ee48#npm:7.8.3"]
+            ["@babel/plugin-syntax-optional-catch-binding", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-proposal-optional-chaining", [
         ["virtual:2ceb4517298ac0ac865b67630b09dbd12ce833d767bf3f69c8877bfcc9911d47df368a52689e47616990fc75abebc9a356eb981a9665ae81bc2c7516cedb8735#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-optional-chaining-virtual-2bd503069b/4/.yarncache/berry/cache/@babel-plugin-proposal-optional-chaining-npm-7.8.3-11636bc994-2.zip/node_modules/@babel/plugin-proposal-optional-chaining/",
           "packageDependencies": [
@@ -1194,7 +1134,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/plugin-proposal-optional-chaining", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.3"],
-            ["@babel/plugin-syntax-optional-chaining", "virtual:a84042cba769adb2e1a20888b5e698e93cdbacbd22d935dc93f12c2edae767e12e2ccb5fd7b839d2fdda56ac7f51361d3452737fd289b63ec372aefdb263ee48#npm:7.8.3"]
+            ["@babel/plugin-syntax-optional-chaining", "virtual:b6aaf2ac4c489c15fd3dbc77810a8926f96c5c2f3dc2d656e0980d39c50f0db3613531e235e2c4a52eeeeae552daa809caf802f959aea2f43bebb00cb787ecd3#npm:7.8.3"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -1203,12 +1143,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-proposal-private-methods", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-private-methods-virtual-90d8397439/4/.yarncache/berry/cache/@babel-plugin-proposal-private-methods-npm-7.10.1-a26a26a78b-2.zip/node_modules/@babel/plugin-proposal-private-methods/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-private-methods-virtual-450fb273b0/4/.yarncache/berry/cache/@babel-plugin-proposal-private-methods-npm-7.10.1-a26a26a78b-2.zip/node_modules/@babel/plugin-proposal-private-methods/",
           "packageDependencies": [
-            ["@babel/plugin-proposal-private-methods", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-private-methods", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-create-class-features-plugin", "virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.2"],
+            ["@babel/helper-create-class-features-plugin", "virtual:77bb6fe4c36ca148778627d74836622e4a1d08d1af7f096c0e34c7177a510195b1a44234d01cfc075bb26b611839524c5c4115d5a5b6d99858f927ca8e310a32#npm:7.10.2"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
@@ -1218,19 +1158,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-proposal-unicode-property-regex", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-unicode-property-regex-virtual-9c49dc8da7/4/.yarncache/berry/cache/@babel-plugin-proposal-unicode-property-regex-npm-7.10.1-59485748b7-2.zip/node_modules/@babel/plugin-proposal-unicode-property-regex/",
-          "packageDependencies": [
-            ["@babel/plugin-proposal-unicode-property-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-create-regexp-features-plugin", "virtual:9c49dc8da71cec43a660f2958f0f1f311bb7662b7e19e7f70a1586dea8e1f156be228a1872e8d06ed1d2d7fc5051cd177bb87f2c11fd580e56b70bfdd18cde77#npm:7.10.1"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-unicode-property-regex-virtual-6be1a752b3/4/.yarncache/berry/cache/@babel-plugin-proposal-unicode-property-regex-npm-7.8.3-d1028b5566-2.zip/node_modules/@babel/plugin-proposal-unicode-property-regex/",
           "packageDependencies": [
@@ -1243,21 +1170,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-syntax-async-generators", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.4", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-async-generators-virtual-b1f62bd874/4/.yarncache/berry/cache/@babel-plugin-syntax-async-generators-npm-7.8.4-d10cf993c9-2.zip/node_modules/@babel/plugin-syntax-async-generators/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-unicode-property-regex-virtual-cb8f80b618/4/.yarncache/berry/cache/@babel-plugin-proposal-unicode-property-regex-npm-7.10.1-59485748b7-2.zip/node_modules/@babel/plugin-proposal-unicode-property-regex/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-async-generators", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.4"],
+            ["@babel/plugin-proposal-unicode-property-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.8.3"]
+            ["@babel/helper-create-regexp-features-plugin", "virtual:cb8f80b61844cfdb1368d4bef351f30e068e6bd6d28b5a6ae078016a4ca8ce939c7f9c144ed8da631f977730ffe43f4be84ec10ceda87dd1b380ed16e0eedb05#npm:7.10.1"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-syntax-async-generators", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.4", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-async-generators-virtual-5fa3255bf5/4/.yarncache/berry/cache/@babel-plugin-syntax-async-generators-npm-7.8.4-d10cf993c9-2.zip/node_modules/@babel/plugin-syntax-async-generators/",
           "packageDependencies": [
@@ -1269,13 +1197,25 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.4", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-async-generators-virtual-45cbf2d13b/4/.yarncache/berry/cache/@babel-plugin-syntax-async-generators-npm-7.8.4-d10cf993c9-2.zip/node_modules/@babel/plugin-syntax-async-generators/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-async-generators", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.4"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-class-properties", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-class-properties-virtual-11167fe697/4/.yarncache/berry/cache/@babel-plugin-syntax-class-properties-npm-7.10.1-e61265d777-2.zip/node_modules/@babel/plugin-syntax-class-properties/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-class-properties-virtual-a2c9b85162/4/.yarncache/berry/cache/@babel-plugin-syntax-class-properties-npm-7.10.1-e61265d777-2.zip/node_modules/@babel/plugin-syntax-class-properties/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-class-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-syntax-class-properties", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
@@ -1312,10 +1252,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-syntax-flow", [
-        ["virtual:5894225432f9d9095ec3a7693381624ac2a679d256fa8ca48e3c5ce784bc2940582b5a11e504497d7860f70fabf0c0798f18f99b39364112ccccbf51621ffe29#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-flow-virtual-1d80d9b7e8/4/.yarncache/berry/cache/@babel-plugin-syntax-flow-npm-7.10.1-02a0524cc1-2.zip/node_modules/@babel/plugin-syntax-flow/",
+        ["virtual:7b2b5b8d04373ddc6fa07827b08ee782963c1cb606b33337eaa144c55e046dbadc7e05b9d469f695921159cfad46755a9c978552a450c6907fd6f41e2b2a6526#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-flow-virtual-f08ddca3c7/4/.yarncache/berry/cache/@babel-plugin-syntax-flow-npm-7.10.1-02a0524cc1-2.zip/node_modules/@babel/plugin-syntax-flow/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-flow", "virtual:5894225432f9d9095ec3a7693381624ac2a679d256fa8ca48e3c5ce784bc2940582b5a11e504497d7860f70fabf0c0798f18f99b39364112ccccbf51621ffe29#npm:7.10.1"],
+            ["@babel/plugin-syntax-flow", "virtual:7b2b5b8d04373ddc6fa07827b08ee782963c1cb606b33337eaa144c55e046dbadc7e05b9d469f695921159cfad46755a9c978552a450c6907fd6f41e2b2a6526#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
@@ -1326,10 +1266,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-syntax-json-strings", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-json-strings-virtual-6bd8fdf972/4/.yarncache/berry/cache/@babel-plugin-syntax-json-strings-npm-7.8.3-6dc7848179-2.zip/node_modules/@babel/plugin-syntax-json-strings/",
+        ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-json-strings-virtual-125a2b53c8/4/.yarncache/berry/cache/@babel-plugin-syntax-json-strings-npm-7.8.3-6dc7848179-2.zip/node_modules/@babel/plugin-syntax-json-strings/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
+            ["@babel/plugin-syntax-json-strings", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
           ],
@@ -1338,10 +1278,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-json-strings-virtual-125a2b53c8/4/.yarncache/berry/cache/@babel-plugin-syntax-json-strings-npm-7.8.3-6dc7848179-2.zip/node_modules/@babel/plugin-syntax-json-strings/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-json-strings-virtual-2b84317f4b/4/.yarncache/berry/cache/@babel-plugin-syntax-json-strings-npm-7.8.3-6dc7848179-2.zip/node_modules/@babel/plugin-syntax-json-strings/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-json-strings", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3"],
+            ["@babel/plugin-syntax-json-strings", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
           ],
@@ -1364,10 +1304,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:fff56b84a6fe174be46b61ca5616a4daacc10641b0bb522e10a5ce088cfcc1609d93328d3bf7277dfded7d2002c905de4c9322e20f6631f5cc9aba1f161a97d8#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-jsx-virtual-7cd9a04131/4/.yarncache/berry/cache/@babel-plugin-syntax-jsx-npm-7.10.1-fcf61bcafb-2.zip/node_modules/@babel/plugin-syntax-jsx/",
+        ["virtual:fea9aa76cc7a72217a012dac4adbb9f792689d73ba0b06774c6681c5a60eddc9018be86ee68450a89dc7881ea191e8ce1c84d8e343fc6758fbade9681a3ebbd9#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-jsx-virtual-e8feee53de/4/.yarncache/berry/cache/@babel-plugin-syntax-jsx-npm-7.10.1-fcf61bcafb-2.zip/node_modules/@babel/plugin-syntax-jsx/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-jsx", "virtual:fff56b84a6fe174be46b61ca5616a4daacc10641b0bb522e10a5ce088cfcc1609d93328d3bf7277dfded7d2002c905de4c9322e20f6631f5cc9aba1f161a97d8#npm:7.10.1"],
+            ["@babel/plugin-syntax-jsx", "virtual:fea9aa76cc7a72217a012dac4adbb9f792689d73ba0b06774c6681c5a60eddc9018be86ee68450a89dc7881ea191e8ce1c84d8e343fc6758fbade9681a3ebbd9#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
@@ -1378,10 +1318,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-syntax-nullish-coalescing-operator", [
-        ["virtual:eed8eeef4910a2fcdb369cf67775b18fc345b7294b5ee2549a66416f0d97cd1003c839c34213098e4a5c3be0f62d7648e0f42f38c5636f9ee1c6be7865f11c6d#npm:7.8.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-nullish-coalescing-operator-virtual-31cef481e2/4/.yarncache/berry/cache/@babel-plugin-syntax-nullish-coalescing-operator-npm-7.8.3-8a723173b5-2.zip/node_modules/@babel/plugin-syntax-nullish-coalescing-operator/",
+        ["virtual:6366cea8102b4b975891233f0336637b165f817687d86205582a902f3469fded79adf2e2cccd9f9d588e769df97dfc106b124470b2b96fef02858f93d3826038#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-nullish-coalescing-operator-virtual-972b1068fe/4/.yarncache/berry/cache/@babel-plugin-syntax-nullish-coalescing-operator-npm-7.8.3-8a723173b5-2.zip/node_modules/@babel/plugin-syntax-nullish-coalescing-operator/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:eed8eeef4910a2fcdb369cf67775b18fc345b7294b5ee2549a66416f0d97cd1003c839c34213098e4a5c3be0f62d7648e0f42f38c5636f9ee1c6be7865f11c6d#npm:7.8.3"],
+            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:6366cea8102b4b975891233f0336637b165f817687d86205582a902f3469fded79adf2e2cccd9f9d588e769df97dfc106b124470b2b96fef02858f93d3826038#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
           ],
@@ -1404,10 +1344,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-syntax-numeric-separator", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-numeric-separator-virtual-1949c7a74f/4/.yarncache/berry/cache/@babel-plugin-syntax-numeric-separator-npm-7.10.1-dcdbebbf6a-2.zip/node_modules/@babel/plugin-syntax-numeric-separator/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-numeric-separator-virtual-59709a1cab/4/.yarncache/berry/cache/@babel-plugin-syntax-numeric-separator-npm-7.10.1-dcdbebbf6a-2.zip/node_modules/@babel/plugin-syntax-numeric-separator/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-syntax-numeric-separator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
@@ -1418,18 +1358,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-syntax-object-rest-spread", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-object-rest-spread-virtual-a1140c94c6/4/.yarncache/berry/cache/@babel-plugin-syntax-object-rest-spread-npm-7.8.3-60bd05b6ae-2.zip/node_modules/@babel/plugin-syntax-object-rest-spread/",
-          "packageDependencies": [
-            ["@babel/plugin-syntax-object-rest-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.8.3"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-object-rest-spread-virtual-019de22f2c/4/.yarncache/berry/cache/@babel-plugin-syntax-object-rest-spread-npm-7.8.3-60bd05b6ae-2.zip/node_modules/@babel/plugin-syntax-object-rest-spread/",
           "packageDependencies": [
@@ -1441,13 +1369,25 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-object-rest-spread-virtual-f60f5eea0f/4/.yarncache/berry/cache/@babel-plugin-syntax-object-rest-spread-npm-7.8.3-60bd05b6ae-2.zip/node_modules/@babel/plugin-syntax-object-rest-spread/",
+          "packageDependencies": [
+            ["@babel/plugin-syntax-object-rest-spread", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-syntax-optional-catch-binding", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-optional-catch-binding-virtual-5e09e1b8bc/4/.yarncache/berry/cache/@babel-plugin-syntax-optional-catch-binding-npm-7.8.3-ce337427d8-2.zip/node_modules/@babel/plugin-syntax-optional-catch-binding/",
+        ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-optional-catch-binding-virtual-9d7212d1a8/4/.yarncache/berry/cache/@babel-plugin-syntax-optional-catch-binding-npm-7.8.3-ce337427d8-2.zip/node_modules/@babel/plugin-syntax-optional-catch-binding/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-optional-catch-binding", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-catch-binding", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
           ],
@@ -1456,10 +1396,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-optional-catch-binding-virtual-9d7212d1a8/4/.yarncache/berry/cache/@babel-plugin-syntax-optional-catch-binding-npm-7.8.3-ce337427d8-2.zip/node_modules/@babel/plugin-syntax-optional-catch-binding/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-optional-catch-binding-virtual-0c89908cae/4/.yarncache/berry/cache/@babel-plugin-syntax-optional-catch-binding-npm-7.8.3-ce337427d8-2.zip/node_modules/@babel/plugin-syntax-optional-catch-binding/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-optional-catch-binding", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-catch-binding", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
           ],
@@ -1482,10 +1422,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:a84042cba769adb2e1a20888b5e698e93cdbacbd22d935dc93f12c2edae767e12e2ccb5fd7b839d2fdda56ac7f51361d3452737fd289b63ec372aefdb263ee48#npm:7.8.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-optional-chaining-virtual-c6ec8c75be/4/.yarncache/berry/cache/@babel-plugin-syntax-optional-chaining-npm-7.8.3-f3f3c79579-2.zip/node_modules/@babel/plugin-syntax-optional-chaining/",
+        ["virtual:b6aaf2ac4c489c15fd3dbc77810a8926f96c5c2f3dc2d656e0980d39c50f0db3613531e235e2c4a52eeeeae552daa809caf802f959aea2f43bebb00cb787ecd3#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-optional-chaining-virtual-4e01db731d/4/.yarncache/berry/cache/@babel-plugin-syntax-optional-chaining-npm-7.8.3-f3f3c79579-2.zip/node_modules/@babel/plugin-syntax-optional-chaining/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-optional-chaining", "virtual:a84042cba769adb2e1a20888b5e698e93cdbacbd22d935dc93f12c2edae767e12e2ccb5fd7b839d2fdda56ac7f51361d3452737fd289b63ec372aefdb263ee48#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-chaining", "virtual:b6aaf2ac4c489c15fd3dbc77810a8926f96c5c2f3dc2d656e0980d39c50f0db3613531e235e2c4a52eeeeae552daa809caf802f959aea2f43bebb00cb787ecd3#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
           ],
@@ -1496,18 +1436,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-syntax-top-level-await", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-top-level-await-virtual-c6e9a49ebe/4/.yarncache/berry/cache/@babel-plugin-syntax-top-level-await-npm-7.10.1-02a20be826-2.zip/node_modules/@babel/plugin-syntax-top-level-await/",
-          "packageDependencies": [
-            ["@babel/plugin-syntax-top-level-await", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-top-level-await-virtual-6c99c4f9ef/4/.yarncache/berry/cache/@babel-plugin-syntax-top-level-await-npm-7.8.3-bf0ee7fa58-2.zip/node_modules/@babel/plugin-syntax-top-level-await/",
           "packageDependencies": [
@@ -1519,13 +1447,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-syntax-typescript", [
-        ["virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-typescript-virtual-d6560699f0/4/.yarncache/berry/cache/@babel-plugin-syntax-typescript-npm-7.10.1-c5673b855e-2.zip/node_modules/@babel/plugin-syntax-typescript/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-top-level-await-virtual-01df6f2f87/4/.yarncache/berry/cache/@babel-plugin-syntax-top-level-await-npm-7.10.1-02a20be826-2.zip/node_modules/@babel/plugin-syntax-top-level-await/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-typescript", "virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.1"],
+            ["@babel/plugin-syntax-top-level-await", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
@@ -1533,7 +1459,9 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-syntax-typescript", [
         ["virtual:966583c773fae0191e70ac7c5a4a5462f814d08b85aa508ae2236b57862f49bf579964987cfa4e8b6a0f9005c0b0752b38c3a4553582ca8172bf8e5dd878749b#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-typescript-virtual-7c48a26913/4/.yarncache/berry/cache/@babel-plugin-syntax-typescript-npm-7.8.3-375b335000-2.zip/node_modules/@babel/plugin-syntax-typescript/",
           "packageDependencies": [
@@ -1545,13 +1473,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-arrow-functions", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-arrow-functions-virtual-70acaf52cd/4/.yarncache/berry/cache/@babel-plugin-transform-arrow-functions-npm-7.10.1-f2fd7b2571-2.zip/node_modules/@babel/plugin-transform-arrow-functions/",
+        }],
+        ["virtual:bcd7c93c8801fd258e0ad62676110ca91947d5f855189c47b4245169dc84b36adc535e9c1ec60f9722dbf3c5fef0b1f02cb9277b8abcb7de0f69c11840775828#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-typescript-virtual-c2eff7acef/4/.yarncache/berry/cache/@babel-plugin-syntax-typescript-npm-7.10.1-c5673b855e-2.zip/node_modules/@babel/plugin-syntax-typescript/",
           "packageDependencies": [
-            ["@babel/plugin-transform-arrow-functions", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-syntax-typescript", "virtual:bcd7c93c8801fd258e0ad62676110ca91947d5f855189c47b4245169dc84b36adc535e9c1ec60f9722dbf3c5fef0b1f02cb9277b8abcb7de0f69c11840775828#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
@@ -1559,7 +1485,9 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-arrow-functions", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-arrow-functions-virtual-9ba5fb9b7f/4/.yarncache/berry/cache/@babel-plugin-transform-arrow-functions-npm-7.8.3-b4620a3bc3-2.zip/node_modules/@babel/plugin-transform-arrow-functions/",
           "packageDependencies": [
@@ -1571,23 +1499,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-async-to-generator", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-async-to-generator-virtual-b9331a8c24/4/.yarncache/berry/cache/@babel-plugin-transform-async-to-generator-npm-7.10.1-1f2922ce80-2.zip/node_modules/@babel/plugin-transform-async-to-generator/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-arrow-functions-virtual-e36be74d30/4/.yarncache/berry/cache/@babel-plugin-transform-arrow-functions-npm-7.10.1-f2fd7b2571-2.zip/node_modules/@babel/plugin-transform-arrow-functions/",
           "packageDependencies": [
-            ["@babel/plugin-transform-async-to-generator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-arrow-functions", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-module-imports", "npm:7.10.1"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/helper-remap-async-to-generator", "npm:7.10.1"]
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-async-to-generator", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-async-to-generator-virtual-ec2f1f4fb6/4/.yarncache/berry/cache/@babel-plugin-transform-async-to-generator-npm-7.8.3-9884b08873-2.zip/node_modules/@babel/plugin-transform-async-to-generator/",
           "packageDependencies": [
@@ -1601,21 +1527,23 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-block-scoped-functions", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-block-scoped-functions-virtual-727a44fa77/4/.yarncache/berry/cache/@babel-plugin-transform-block-scoped-functions-npm-7.10.1-81170296a0-2.zip/node_modules/@babel/plugin-transform-block-scoped-functions/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-async-to-generator-virtual-0b317151bf/4/.yarncache/berry/cache/@babel-plugin-transform-async-to-generator-npm-7.10.1-1f2922ce80-2.zip/node_modules/@babel/plugin-transform-async-to-generator/",
           "packageDependencies": [
-            ["@babel/plugin-transform-block-scoped-functions", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-async-to-generator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
+            ["@babel/helper-module-imports", "npm:7.10.1"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"],
+            ["@babel/helper-remap-async-to-generator", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-block-scoped-functions", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-block-scoped-functions-virtual-0658355f67/4/.yarncache/berry/cache/@babel-plugin-transform-block-scoped-functions-npm-7.8.3-83b18d8a13-2.zip/node_modules/@babel/plugin-transform-block-scoped-functions/",
           "packageDependencies": [
@@ -1627,22 +1555,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-block-scoping", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-block-scoping-virtual-f3184a6270/4/.yarncache/berry/cache/@babel-plugin-transform-block-scoping-npm-7.10.1-dd5cd7f209-2.zip/node_modules/@babel/plugin-transform-block-scoping/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-block-scoped-functions-virtual-2d71661735/4/.yarncache/berry/cache/@babel-plugin-transform-block-scoped-functions-npm-7.10.1-81170296a0-2.zip/node_modules/@babel/plugin-transform-block-scoped-functions/",
           "packageDependencies": [
-            ["@babel/plugin-transform-block-scoping", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-block-scoped-functions", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["lodash", "npm:4.17.15"]
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-block-scoping", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-block-scoping-virtual-fd8e6fe28f/4/.yarncache/berry/cache/@babel-plugin-transform-block-scoping-npm-7.8.3-af8a5f63e3-2.zip/node_modules/@babel/plugin-transform-block-scoping/",
           "packageDependencies": [
@@ -1655,28 +1582,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-classes", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-classes-virtual-fc7c9d4408/4/.yarncache/berry/cache/@babel-plugin-transform-classes-npm-7.10.1-784ec55e37-2.zip/node_modules/@babel/plugin-transform-classes/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-block-scoping-virtual-959c8a0333/4/.yarncache/berry/cache/@babel-plugin-transform-block-scoping-npm-7.10.1-dd5cd7f209-2.zip/node_modules/@babel/plugin-transform-block-scoping/",
           "packageDependencies": [
-            ["@babel/plugin-transform-classes", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-block-scoping", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-annotate-as-pure", "npm:7.10.1"],
-            ["@babel/helper-define-map", "npm:7.10.1"],
-            ["@babel/helper-function-name", "npm:7.10.1"],
-            ["@babel/helper-optimise-call-expression", "npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/helper-replace-supers", "npm:7.10.1"],
-            ["@babel/helper-split-export-declaration", "npm:7.10.1"],
-            ["globals", "npm:11.12.0"]
+            ["lodash", "npm:4.17.15"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-classes", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.6", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-classes-virtual-91af9824e4/4/.yarncache/berry/cache/@babel-plugin-transform-classes-npm-7.8.6-1759d1e5b0-2.zip/node_modules/@babel/plugin-transform-classes/",
           "packageDependencies": [
@@ -1717,18 +1638,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-computed-properties", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-computed-properties-virtual-26e3d9ad8b/4/.yarncache/berry/cache/@babel-plugin-transform-computed-properties-npm-7.10.1-4c678892b2-2.zip/node_modules/@babel/plugin-transform-computed-properties/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-computed-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-computed-properties-virtual-6ac0a14b8e/4/.yarncache/berry/cache/@babel-plugin-transform-computed-properties-npm-7.8.3-a62102387f-2.zip/node_modules/@babel/plugin-transform-computed-properties/",
           "packageDependencies": [
@@ -1755,18 +1664,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-destructuring", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-destructuring-virtual-1f89f00eec/4/.yarncache/berry/cache/@babel-plugin-transform-destructuring-npm-7.10.1-ec734c55ca-2.zip/node_modules/@babel/plugin-transform-destructuring/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-destructuring", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-destructuring-virtual-16aabe67d5/4/.yarncache/berry/cache/@babel-plugin-transform-destructuring-npm-7.8.3-e824cabb88-2.zip/node_modules/@babel/plugin-transform-destructuring/",
           "packageDependencies": [
@@ -1778,22 +1675,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-dotall-regex", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-dotall-regex-virtual-31bf08f9d2/4/.yarncache/berry/cache/@babel-plugin-transform-dotall-regex-npm-7.10.1-064f3d041e-2.zip/node_modules/@babel/plugin-transform-dotall-regex/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-destructuring-virtual-b86c7ad64f/4/.yarncache/berry/cache/@babel-plugin-transform-destructuring-npm-7.10.1-ec734c55ca-2.zip/node_modules/@babel/plugin-transform-destructuring/",
           "packageDependencies": [
-            ["@babel/plugin-transform-dotall-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-destructuring", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-create-regexp-features-plugin", "virtual:9c49dc8da71cec43a660f2958f0f1f311bb7662b7e19e7f70a1586dea8e1f156be228a1872e8d06ed1d2d7fc5051cd177bb87f2c11fd580e56b70bfdd18cde77#npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-dotall-regex", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-dotall-regex-virtual-4e1c992139/4/.yarncache/berry/cache/@babel-plugin-transform-dotall-regex-npm-7.8.3-f182ec3dca-2.zip/node_modules/@babel/plugin-transform-dotall-regex/",
           "packageDependencies": [
@@ -1806,21 +1702,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-duplicate-keys", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-duplicate-keys-virtual-eef06c394c/4/.yarncache/berry/cache/@babel-plugin-transform-duplicate-keys-npm-7.10.1-80e18b5028-2.zip/node_modules/@babel/plugin-transform-duplicate-keys/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-dotall-regex-virtual-090fc5a645/4/.yarncache/berry/cache/@babel-plugin-transform-dotall-regex-npm-7.10.1-064f3d041e-2.zip/node_modules/@babel/plugin-transform-dotall-regex/",
           "packageDependencies": [
-            ["@babel/plugin-transform-duplicate-keys", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-dotall-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-create-regexp-features-plugin", "virtual:cb8f80b61844cfdb1368d4bef351f30e068e6bd6d28b5a6ae078016a4ca8ce939c7f9c144ed8da631f977730ffe43f4be84ec10ceda87dd1b380ed16e0eedb05#npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-duplicate-keys", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-duplicate-keys-virtual-a74c2e6c5c/4/.yarncache/berry/cache/@babel-plugin-transform-duplicate-keys-npm-7.8.3-432c4ead45-2.zip/node_modules/@babel/plugin-transform-duplicate-keys/",
           "packageDependencies": [
@@ -1832,22 +1729,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-exponentiation-operator", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-exponentiation-operator-virtual-265488da68/4/.yarncache/berry/cache/@babel-plugin-transform-exponentiation-operator-npm-7.10.1-402ac4a41c-2.zip/node_modules/@babel/plugin-transform-exponentiation-operator/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-duplicate-keys-virtual-85b2c950f2/4/.yarncache/berry/cache/@babel-plugin-transform-duplicate-keys-npm-7.10.1-80e18b5028-2.zip/node_modules/@babel/plugin-transform-duplicate-keys/",
           "packageDependencies": [
-            ["@babel/plugin-transform-exponentiation-operator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-duplicate-keys", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-builder-binary-assignment-operator-visitor", "npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-exponentiation-operator", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-exponentiation-operator-virtual-9cc82c5460/4/.yarncache/berry/cache/@babel-plugin-transform-exponentiation-operator-npm-7.8.3-16abde80f7-2.zip/node_modules/@babel/plugin-transform-exponentiation-operator/",
           "packageDependencies": [
@@ -1860,16 +1756,29 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-exponentiation-operator-virtual-3e158b7a01/4/.yarncache/berry/cache/@babel-plugin-transform-exponentiation-operator-npm-7.10.1-402ac4a41c-2.zip/node_modules/@babel/plugin-transform-exponentiation-operator/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-exponentiation-operator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-builder-binary-assignment-operator-visitor", "npm:7.10.1"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-transform-flow-strip-types", [
-        ["virtual:3de52e135f6b931c379d710a63f060759811b923879cb7aaab78d3eebb01fd1bd2463208cae513a126de66039c841eb067d82925208875be3a99cd629465d431#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-flow-strip-types-virtual-5894225432/4/.yarncache/berry/cache/@babel-plugin-transform-flow-strip-types-npm-7.10.1-510b1169e1-2.zip/node_modules/@babel/plugin-transform-flow-strip-types/",
+        ["virtual:94794d58f84ad87e928143cc6326a93430b89c3f7792598aa4eb46bc3903ec039939f0c3d17ffbb857dca4078e8e1619111d0b93a2db11e2fff59ff3db4ea78e#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-flow-strip-types-virtual-7b2b5b8d04/4/.yarncache/berry/cache/@babel-plugin-transform-flow-strip-types-npm-7.10.1-510b1169e1-2.zip/node_modules/@babel/plugin-transform-flow-strip-types/",
           "packageDependencies": [
-            ["@babel/plugin-transform-flow-strip-types", "virtual:3de52e135f6b931c379d710a63f060759811b923879cb7aaab78d3eebb01fd1bd2463208cae513a126de66039c841eb067d82925208875be3a99cd629465d431#npm:7.10.1"],
+            ["@babel/plugin-transform-flow-strip-types", "virtual:94794d58f84ad87e928143cc6326a93430b89c3f7792598aa4eb46bc3903ec039939f0c3d17ffbb857dca4078e8e1619111d0b93a2db11e2fff59ff3db4ea78e#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-flow", "virtual:5894225432f9d9095ec3a7693381624ac2a679d256fa8ca48e3c5ce784bc2940582b5a11e504497d7860f70fabf0c0798f18f99b39364112ccccbf51621ffe29#npm:7.10.1"]
+            ["@babel/plugin-syntax-flow", "virtual:7b2b5b8d04373ddc6fa07827b08ee782963c1cb606b33337eaa144c55e046dbadc7e05b9d469f695921159cfad46755a9c978552a450c6907fd6f41e2b2a6526#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -1878,18 +1787,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-for-of", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-for-of-virtual-02defc146e/4/.yarncache/berry/cache/@babel-plugin-transform-for-of-npm-7.10.1-59eadd25a8-2.zip/node_modules/@babel/plugin-transform-for-of/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-for-of", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.6", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-for-of-virtual-e2526643f3/4/.yarncache/berry/cache/@babel-plugin-transform-for-of-npm-7.8.6-aa045e1a0d-2.zip/node_modules/@babel/plugin-transform-for-of/",
           "packageDependencies": [
@@ -1901,22 +1798,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-function-name", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-function-name-virtual-27ec24c5c9/4/.yarncache/berry/cache/@babel-plugin-transform-function-name-npm-7.10.1-c511489b14-2.zip/node_modules/@babel/plugin-transform-function-name/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-for-of-virtual-44b6ed8e0e/4/.yarncache/berry/cache/@babel-plugin-transform-for-of-npm-7.10.1-59eadd25a8-2.zip/node_modules/@babel/plugin-transform-for-of/",
           "packageDependencies": [
-            ["@babel/plugin-transform-function-name", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-for-of", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-function-name", "npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-function-name", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-function-name-virtual-487b95c6ee/4/.yarncache/berry/cache/@babel-plugin-transform-function-name-npm-7.8.3-78d652f0f7-2.zip/node_modules/@babel/plugin-transform-function-name/",
           "packageDependencies": [
@@ -1929,21 +1825,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-literals", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-literals-virtual-935481b642/4/.yarncache/berry/cache/@babel-plugin-transform-literals-npm-7.10.1-dfcdbd57cc-2.zip/node_modules/@babel/plugin-transform-literals/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-function-name-virtual-657fcc491b/4/.yarncache/berry/cache/@babel-plugin-transform-function-name-npm-7.10.1-c511489b14-2.zip/node_modules/@babel/plugin-transform-function-name/",
           "packageDependencies": [
-            ["@babel/plugin-transform-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-function-name", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-function-name", "npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-literals", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-literals-virtual-928f6bb0c9/4/.yarncache/berry/cache/@babel-plugin-transform-literals-npm-7.8.3-24245670a4-2.zip/node_modules/@babel/plugin-transform-literals/",
           "packageDependencies": [
@@ -1955,13 +1852,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-member-expression-literals", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-member-expression-literals-virtual-f3b3373911/4/.yarncache/berry/cache/@babel-plugin-transform-member-expression-literals-npm-7.10.1-1cb2fa3b45-2.zip/node_modules/@babel/plugin-transform-member-expression-literals/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-literals-virtual-c1cbf3fe0d/4/.yarncache/berry/cache/@babel-plugin-transform-literals-npm-7.10.1-dfcdbd57cc-2.zip/node_modules/@babel/plugin-transform-literals/",
           "packageDependencies": [
-            ["@babel/plugin-transform-member-expression-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-literals", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
@@ -1969,7 +1864,9 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-member-expression-literals", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-member-expression-literals-virtual-9e840b5427/4/.yarncache/berry/cache/@babel-plugin-transform-member-expression-literals-npm-7.8.3-7593b23c61-2.zip/node_modules/@babel/plugin-transform-member-expression-literals/",
           "packageDependencies": [
@@ -1981,23 +1878,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-modules-amd", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-amd-virtual-37d33d3aa7/4/.yarncache/berry/cache/@babel-plugin-transform-modules-amd-npm-7.10.1-3e52da1ab8-2.zip/node_modules/@babel/plugin-transform-modules-amd/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-member-expression-literals-virtual-59d93cf154/4/.yarncache/berry/cache/@babel-plugin-transform-member-expression-literals-npm-7.10.1-1cb2fa3b45-2.zip/node_modules/@babel/plugin-transform-member-expression-literals/",
           "packageDependencies": [
-            ["@babel/plugin-transform-modules-amd", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-member-expression-literals", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-module-transforms", "npm:7.10.1"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["babel-plugin-dynamic-import-node", "npm:2.3.3"]
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-modules-amd", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-amd-virtual-eff035e470/4/.yarncache/berry/cache/@babel-plugin-transform-modules-amd-npm-7.8.3-7d1f21afdd-2.zip/node_modules/@babel/plugin-transform-modules-amd/",
           "packageDependencies": [
@@ -2011,24 +1906,23 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-modules-commonjs", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-commonjs-virtual-b5025b82d5/4/.yarncache/berry/cache/@babel-plugin-transform-modules-commonjs-npm-7.10.1-1009069af9-2.zip/node_modules/@babel/plugin-transform-modules-commonjs/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-amd-virtual-4edd58e846/4/.yarncache/berry/cache/@babel-plugin-transform-modules-amd-npm-7.10.1-3e52da1ab8-2.zip/node_modules/@babel/plugin-transform-modules-amd/",
           "packageDependencies": [
-            ["@babel/plugin-transform-modules-commonjs", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-modules-amd", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-module-transforms", "npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/helper-simple-access", "npm:7.10.1"],
             ["babel-plugin-dynamic-import-node", "npm:2.3.3"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-modules-commonjs", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-commonjs-virtual-be792abc6e/4/.yarncache/berry/cache/@babel-plugin-transform-modules-commonjs-npm-7.8.3-823f8c38f6-2.zip/node_modules/@babel/plugin-transform-modules-commonjs/",
           "packageDependencies": [
@@ -2043,24 +1937,24 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-modules-systemjs", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-systemjs-virtual-f250e50257/4/.yarncache/berry/cache/@babel-plugin-transform-modules-systemjs-npm-7.10.1-ecc92673af-2.zip/node_modules/@babel/plugin-transform-modules-systemjs/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-commonjs-virtual-cbc9afdb8c/4/.yarncache/berry/cache/@babel-plugin-transform-modules-commonjs-npm-7.10.1-1009069af9-2.zip/node_modules/@babel/plugin-transform-modules-commonjs/",
           "packageDependencies": [
-            ["@babel/plugin-transform-modules-systemjs", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-modules-commonjs", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-hoist-variables", "npm:7.10.1"],
             ["@babel/helper-module-transforms", "npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
+            ["@babel/helper-simple-access", "npm:7.10.1"],
             ["babel-plugin-dynamic-import-node", "npm:2.3.3"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-modules-systemjs", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-systemjs-virtual-7382c5062d/4/.yarncache/berry/cache/@babel-plugin-transform-modules-systemjs-npm-7.8.3-08b1efac95-2.zip/node_modules/@babel/plugin-transform-modules-systemjs/",
           "packageDependencies": [
@@ -2093,19 +1987,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-modules-umd", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-umd-virtual-c7413ff9f8/4/.yarncache/berry/cache/@babel-plugin-transform-modules-umd-npm-7.10.1-921e160b48-2.zip/node_modules/@babel/plugin-transform-modules-umd/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-modules-umd", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-module-transforms", "npm:7.10.1"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-umd-virtual-107ec23092/4/.yarncache/berry/cache/@babel-plugin-transform-modules-umd-npm-7.8.3-8016fa1214-2.zip/node_modules/@babel/plugin-transform-modules-umd/",
           "packageDependencies": [
@@ -2118,21 +1999,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-named-capturing-groups-regex", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-named-capturing-groups-regex-virtual-1120c66e38/4/.yarncache/berry/cache/@babel-plugin-transform-named-capturing-groups-regex-npm-7.8.3-a45cffa2da-2.zip/node_modules/@babel/plugin-transform-named-capturing-groups-regex/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-umd-virtual-be3dafb294/4/.yarncache/berry/cache/@babel-plugin-transform-modules-umd-npm-7.10.1-921e160b48-2.zip/node_modules/@babel/plugin-transform-modules-umd/",
           "packageDependencies": [
-            ["@babel/plugin-transform-named-capturing-groups-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
+            ["@babel/plugin-transform-modules-umd", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-create-regexp-features-plugin", "virtual:1120c66e38adff9979f67f86ce6b7edd627879c20f265b980ac89f877f836fb4605ec49465b7034da6a10dad2fdd19c2868176e1945a9635a3c5f9b32d8260f2#npm:7.8.6"]
+            ["@babel/helper-module-transforms", "npm:7.10.1"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-named-capturing-groups-regex", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-named-capturing-groups-regex-virtual-12d47cc00c/4/.yarncache/berry/cache/@babel-plugin-transform-named-capturing-groups-regex-npm-7.8.3-a45cffa2da-2.zip/node_modules/@babel/plugin-transform-named-capturing-groups-regex/",
           "packageDependencies": [
@@ -2150,7 +2032,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/plugin-transform-named-capturing-groups-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-create-regexp-features-plugin", "virtual:1120c66e38adff9979f67f86ce6b7edd627879c20f265b980ac89f877f836fb4605ec49465b7034da6a10dad2fdd19c2868176e1945a9635a3c5f9b32d8260f2#npm:7.8.6"]
+            ["@babel/helper-create-regexp-features-plugin", "virtual:50f975f857a68e232fbc6167e59f798f4a64bd215d8b552a504d648c0809ed1865be1b4a48c22744bd4155c762e609c9d6bba183b4b5d9b975223210398208ba#npm:7.8.6"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2159,18 +2041,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-new-target", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-new-target-virtual-a077011f50/4/.yarncache/berry/cache/@babel-plugin-transform-new-target-npm-7.10.1-f0aed7781f-2.zip/node_modules/@babel/plugin-transform-new-target/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-new-target", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-new-target-virtual-473e01dcd8/4/.yarncache/berry/cache/@babel-plugin-transform-new-target-npm-7.8.3-d0d263e17f-2.zip/node_modules/@babel/plugin-transform-new-target/",
           "packageDependencies": [
@@ -2182,22 +2052,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-object-super", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-object-super-virtual-8506e2b74c/4/.yarncache/berry/cache/@babel-plugin-transform-object-super-npm-7.10.1-81d0144e9d-2.zip/node_modules/@babel/plugin-transform-object-super/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-new-target-virtual-84cb698eb7/4/.yarncache/berry/cache/@babel-plugin-transform-new-target-npm-7.10.1-f0aed7781f-2.zip/node_modules/@babel/plugin-transform-new-target/",
           "packageDependencies": [
-            ["@babel/plugin-transform-object-super", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-new-target", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/helper-replace-supers", "npm:7.10.1"]
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-object-super", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-object-super-virtual-e56a411fa6/4/.yarncache/berry/cache/@babel-plugin-transform-object-super-npm-7.8.3-90a3e9b776-2.zip/node_modules/@babel/plugin-transform-object-super/",
           "packageDependencies": [
@@ -2210,22 +2079,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-parameters", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-parameters-virtual-e5e1af0527/4/.yarncache/berry/cache/@babel-plugin-transform-parameters-npm-7.10.1-df9b36a47f-2.zip/node_modules/@babel/plugin-transform-parameters/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-object-super-virtual-0a14beb31c/4/.yarncache/berry/cache/@babel-plugin-transform-object-super-npm-7.10.1-81d0144e9d-2.zip/node_modules/@babel/plugin-transform-object-super/",
           "packageDependencies": [
-            ["@babel/plugin-transform-parameters", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-object-super", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-get-function-arity", "npm:7.10.1"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
+            ["@babel/helper-plugin-utils", "npm:7.10.1"],
+            ["@babel/helper-replace-supers", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-parameters", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.4", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-parameters-virtual-da576cbf3b/4/.yarncache/berry/cache/@babel-plugin-transform-parameters-npm-7.8.4-fe2372d5d2-2.zip/node_modules/@babel/plugin-transform-parameters/",
           "packageDependencies": [
@@ -2239,27 +2108,40 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-property-literals", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-property-literals-virtual-c417dcefb9/4/.yarncache/berry/cache/@babel-plugin-transform-property-literals-npm-7.10.1-0a31e7a0eb-2.zip/node_modules/@babel/plugin-transform-property-literals/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-parameters-virtual-7fa0e9aadf/4/.yarncache/berry/cache/@babel-plugin-transform-parameters-npm-7.10.1-df9b36a47f-2.zip/node_modules/@babel/plugin-transform-parameters/",
           "packageDependencies": [
-            ["@babel/plugin-transform-property-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-parameters", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-get-function-arity", "npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-property-literals", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-property-literals-virtual-2ed9fe8f59/4/.yarncache/berry/cache/@babel-plugin-transform-property-literals-npm-7.8.3-b01bb76729-2.zip/node_modules/@babel/plugin-transform-property-literals/",
           "packageDependencies": [
             ["@babel/plugin-transform-property-literals", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-property-literals-virtual-49fbabe213/4/.yarncache/berry/cache/@babel-plugin-transform-property-literals-npm-7.10.1-0a31e7a0eb-2.zip/node_modules/@babel/plugin-transform-property-literals/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-property-literals", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2280,10 +2162,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-display-name-virtual-00700d670a/4/.yarncache/berry/cache/@babel-plugin-transform-react-display-name-npm-7.10.1-63c9ccca55-2.zip/node_modules/@babel/plugin-transform-react-display-name/",
+        ["virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-display-name-virtual-9ea68f425f/4/.yarncache/berry/cache/@babel-plugin-transform-react-display-name-npm-7.10.1-63c9ccca55-2.zip/node_modules/@babel/plugin-transform-react-display-name/",
           "packageDependencies": [
-            ["@babel/plugin-transform-react-display-name", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-display-name", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
@@ -2308,15 +2190,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-jsx-virtual-fff56b84a6/4/.yarncache/berry/cache/@babel-plugin-transform-react-jsx-npm-7.10.1-054b034640-2.zip/node_modules/@babel/plugin-transform-react-jsx/",
+        ["virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-jsx-virtual-fea9aa76cc/4/.yarncache/berry/cache/@babel-plugin-transform-react-jsx-npm-7.10.1-054b034640-2.zip/node_modules/@babel/plugin-transform-react-jsx/",
           "packageDependencies": [
-            ["@babel/plugin-transform-react-jsx", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-builder-react-jsx", "npm:7.10.1"],
             ["@babel/helper-builder-react-jsx-experimental", "npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-jsx", "virtual:fff56b84a6fe174be46b61ca5616a4daacc10641b0bb522e10a5ce088cfcc1609d93328d3bf7277dfded7d2002c905de4c9322e20f6631f5cc9aba1f161a97d8#npm:7.10.1"]
+            ["@babel/plugin-syntax-jsx", "virtual:fea9aa76cc7a72217a012dac4adbb9f792689d73ba0b06774c6681c5a60eddc9018be86ee68450a89dc7881ea191e8ce1c84d8e343fc6758fbade9681a3ebbd9#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2325,14 +2207,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-react-jsx-development", [
-        ["virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-jsx-development-virtual-4ba5fdeb6e/4/.yarncache/berry/cache/@babel-plugin-transform-react-jsx-development-npm-7.10.1-b097351dd0-2.zip/node_modules/@babel/plugin-transform-react-jsx-development/",
+        ["virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-jsx-development-virtual-6cca8f2801/4/.yarncache/berry/cache/@babel-plugin-transform-react-jsx-development-npm-7.10.1-b097351dd0-2.zip/node_modules/@babel/plugin-transform-react-jsx-development/",
           "packageDependencies": [
-            ["@babel/plugin-transform-react-jsx-development", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx-development", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-builder-react-jsx-experimental", "npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-jsx", "virtual:fff56b84a6fe174be46b61ca5616a4daacc10641b0bb522e10a5ce088cfcc1609d93328d3bf7277dfded7d2002c905de4c9322e20f6631f5cc9aba1f161a97d8#npm:7.10.1"]
+            ["@babel/plugin-syntax-jsx", "virtual:fea9aa76cc7a72217a012dac4adbb9f792689d73ba0b06774c6681c5a60eddc9018be86ee68450a89dc7881ea191e8ce1c84d8e343fc6758fbade9681a3ebbd9#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2354,13 +2236,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-jsx-self-virtual-32a36dbbf4/4/.yarncache/berry/cache/@babel-plugin-transform-react-jsx-self-npm-7.10.1-6dfeab5ce8-2.zip/node_modules/@babel/plugin-transform-react-jsx-self/",
+        ["virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-jsx-self-virtual-4b812a4031/4/.yarncache/berry/cache/@babel-plugin-transform-react-jsx-self-npm-7.10.1-6dfeab5ce8-2.zip/node_modules/@babel/plugin-transform-react-jsx-self/",
           "packageDependencies": [
-            ["@babel/plugin-transform-react-jsx-self", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx-self", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-jsx", "virtual:fff56b84a6fe174be46b61ca5616a4daacc10641b0bb522e10a5ce088cfcc1609d93328d3bf7277dfded7d2002c905de4c9322e20f6631f5cc9aba1f161a97d8#npm:7.10.1"]
+            ["@babel/plugin-syntax-jsx", "virtual:fea9aa76cc7a72217a012dac4adbb9f792689d73ba0b06774c6681c5a60eddc9018be86ee68450a89dc7881ea191e8ce1c84d8e343fc6758fbade9681a3ebbd9#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2382,13 +2264,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-jsx-source-virtual-11a21e326f/4/.yarncache/berry/cache/@babel-plugin-transform-react-jsx-source-npm-7.10.1-2d5ab1016c-2.zip/node_modules/@babel/plugin-transform-react-jsx-source/",
+        ["virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-jsx-source-virtual-e6eb6e1e46/4/.yarncache/berry/cache/@babel-plugin-transform-react-jsx-source-npm-7.10.1-2d5ab1016c-2.zip/node_modules/@babel/plugin-transform-react-jsx-source/",
           "packageDependencies": [
-            ["@babel/plugin-transform-react-jsx-source", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx-source", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-jsx", "virtual:fff56b84a6fe174be46b61ca5616a4daacc10641b0bb522e10a5ce088cfcc1609d93328d3bf7277dfded7d2002c905de4c9322e20f6631f5cc9aba1f161a97d8#npm:7.10.1"]
+            ["@babel/plugin-syntax-jsx", "virtual:fea9aa76cc7a72217a012dac4adbb9f792689d73ba0b06774c6681c5a60eddc9018be86ee68450a89dc7881ea191e8ce1c84d8e343fc6758fbade9681a3ebbd9#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2397,10 +2279,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-react-pure-annotations", [
-        ["virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-pure-annotations-virtual-851c8ae42e/4/.yarncache/berry/cache/@babel-plugin-transform-react-pure-annotations-npm-7.10.1-7a4495fe5b-2.zip/node_modules/@babel/plugin-transform-react-pure-annotations/",
+        ["virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-react-pure-annotations-virtual-16949aba0f/4/.yarncache/berry/cache/@babel-plugin-transform-react-pure-annotations-npm-7.10.1-7a4495fe5b-2.zip/node_modules/@babel/plugin-transform-react-pure-annotations/",
           "packageDependencies": [
-            ["@babel/plugin-transform-react-pure-annotations", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-pure-annotations", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-annotate-as-pure", "npm:7.10.1"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
@@ -2412,18 +2294,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-regenerator", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-regenerator-virtual-d275a67d28/4/.yarncache/berry/cache/@babel-plugin-transform-regenerator-npm-7.10.1-3ca9779448-2.zip/node_modules/@babel/plugin-transform-regenerator/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-regenerator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["regenerator-transform", "npm:0.14.4"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-regenerator-virtual-63e1dc155b/4/.yarncache/berry/cache/@babel-plugin-transform-regenerator-npm-7.8.3-9370cf06a2-2.zip/node_modules/@babel/plugin-transform-regenerator/",
           "packageDependencies": [
@@ -2450,18 +2320,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-reserved-words", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-reserved-words-virtual-61f9248fbf/4/.yarncache/berry/cache/@babel-plugin-transform-reserved-words-npm-7.10.1-355f310244-2.zip/node_modules/@babel/plugin-transform-reserved-words/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-reserved-words", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-reserved-words-virtual-283d3eb4a6/4/.yarncache/berry/cache/@babel-plugin-transform-reserved-words-npm-7.8.3-beaa938f92-2.zip/node_modules/@babel/plugin-transform-reserved-words/",
           "packageDependencies": [
@@ -2473,24 +2331,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-runtime", [
-        ["virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-runtime-virtual-f3bacc0441/4/.yarncache/berry/cache/@babel-plugin-transform-runtime-npm-7.10.1-9c35bbbd48-2.zip/node_modules/@babel/plugin-transform-runtime/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-reserved-words-virtual-2e5d12c472/4/.yarncache/berry/cache/@babel-plugin-transform-reserved-words-npm-7.10.1-355f310244-2.zip/node_modules/@babel/plugin-transform-reserved-words/",
           "packageDependencies": [
-            ["@babel/plugin-transform-runtime", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
+            ["@babel/plugin-transform-reserved-words", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-module-imports", "npm:7.10.1"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["resolve", "patch:resolve@npm%3A1.15.1#builtin<compat/resolve>::version=1.15.1&hash=8fccd0"],
-            ["semver", "npm:5.7.1"]
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-runtime", [
         ["virtual:2ceb4517298ac0ac865b67630b09dbd12ce833d767bf3f69c8877bfcc9911d47df368a52689e47616990fc75abebc9a356eb981a9665ae81bc2c7516cedb8735#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-runtime-virtual-608c632fbe/4/.yarncache/berry/cache/@babel-plugin-transform-runtime-npm-7.8.3-2e2753bb7c-2.zip/node_modules/@babel/plugin-transform-runtime/",
           "packageDependencies": [
@@ -2523,24 +2378,24 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-shorthand-properties", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-shorthand-properties-virtual-4f006d7cf1/4/.yarncache/berry/cache/@babel-plugin-transform-shorthand-properties-npm-7.10.1-8026d749ab-2.zip/node_modules/@babel/plugin-transform-shorthand-properties/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-shorthand-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-shorthand-properties-virtual-32c3935d21/4/.yarncache/berry/cache/@babel-plugin-transform-shorthand-properties-npm-7.8.3-adf397511f-2.zip/node_modules/@babel/plugin-transform-shorthand-properties/",
           "packageDependencies": [
             ["@babel/plugin-transform-shorthand-properties", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-shorthand-properties-virtual-91f080dcaa/4/.yarncache/berry/cache/@babel-plugin-transform-shorthand-properties-npm-7.10.1-8026d749ab-2.zip/node_modules/@babel/plugin-transform-shorthand-properties/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-shorthand-properties", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2561,10 +2416,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-spread-virtual-8ac65a54da/4/.yarncache/berry/cache/@babel-plugin-transform-spread-npm-7.10.1-e65adab880-2.zip/node_modules/@babel/plugin-transform-spread/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-spread-virtual-5d04507201/4/.yarncache/berry/cache/@babel-plugin-transform-spread-npm-7.10.1-e65adab880-2.zip/node_modules/@babel/plugin-transform-spread/",
           "packageDependencies": [
-            ["@babel/plugin-transform-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-spread", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
@@ -2575,19 +2430,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-sticky-regex", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-sticky-regex-virtual-0e1df4e1e7/4/.yarncache/berry/cache/@babel-plugin-transform-sticky-regex-npm-7.10.1-1168b8f94e-2.zip/node_modules/@babel/plugin-transform-sticky-regex/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-sticky-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/helper-regex", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-sticky-regex-virtual-9608468e5e/4/.yarncache/berry/cache/@babel-plugin-transform-sticky-regex-npm-7.8.3-5dcf5f7f6a-2.zip/node_modules/@babel/plugin-transform-sticky-regex/",
           "packageDependencies": [
@@ -2600,22 +2442,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
-        }]
-      ]],
-      ["@babel/plugin-transform-template-literals", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-template-literals-virtual-640590a434/4/.yarncache/berry/cache/@babel-plugin-transform-template-literals-npm-7.10.1-807d8fc7ca-2.zip/node_modules/@babel/plugin-transform-template-literals/",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-sticky-regex-virtual-6346555b63/4/.yarncache/berry/cache/@babel-plugin-transform-sticky-regex-npm-7.10.1-1168b8f94e-2.zip/node_modules/@babel/plugin-transform-sticky-regex/",
           "packageDependencies": [
-            ["@babel/plugin-transform-template-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-sticky-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-annotate-as-pure", "npm:7.10.1"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
+            ["@babel/helper-plugin-utils", "npm:7.10.1"],
+            ["@babel/helper-regex", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
           ],
           "linkType": "HARD",
-        }],
+        }]
+      ]],
+      ["@babel/plugin-transform-template-literals", [
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-template-literals-virtual-43a9af3cf6/4/.yarncache/berry/cache/@babel-plugin-transform-template-literals-npm-7.8.3-122cf78433-2.zip/node_modules/@babel/plugin-transform-template-literals/",
           "packageDependencies": [
@@ -2644,24 +2486,24 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-typeof-symbol", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-typeof-symbol-virtual-a98a9d08be/4/.yarncache/berry/cache/@babel-plugin-transform-typeof-symbol-npm-7.10.1-8991b4e08e-2.zip/node_modules/@babel/plugin-transform-typeof-symbol/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-typeof-symbol", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.4", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-typeof-symbol-virtual-bae1cad9b1/4/.yarncache/berry/cache/@babel-plugin-transform-typeof-symbol-npm-7.8.4-c3d5ec1323-2.zip/node_modules/@babel/plugin-transform-typeof-symbol/",
           "packageDependencies": [
             ["@babel/plugin-transform-typeof-symbol", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.4"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-typeof-symbol-virtual-f7bb9aa3bd/4/.yarncache/berry/cache/@babel-plugin-transform-typeof-symbol-npm-7.10.1-8991b4e08e-2.zip/node_modules/@babel/plugin-transform-typeof-symbol/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-typeof-symbol", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2684,20 +2526,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-typescript-virtual-5e782ca4d5/4/.yarncache/berry/cache/@babel-plugin-transform-typescript-npm-7.10.1-ca9954d5ca-2.zip/node_modules/@babel/plugin-transform-typescript/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-typescript", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-create-class-features-plugin", "virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.2"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-typescript", "virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-typescript-virtual-bcd7c93c88/4/.yarncache/berry/cache/@babel-plugin-transform-typescript-npm-7.10.3-1fc170ba2e-2.zip/node_modules/@babel/plugin-transform-typescript/",
           "packageDependencies": [
@@ -2705,7 +2533,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-create-class-features-plugin", "virtual:bcd7c93c8801fd258e0ad62676110ca91947d5f855189c47b4245169dc84b36adc535e9c1ec60f9722dbf3c5fef0b1f02cb9277b8abcb7de0f69c11840775828#npm:7.10.3"],
             ["@babel/helper-plugin-utils", "npm:7.10.3"],
-            ["@babel/plugin-syntax-typescript", "virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.1"]
+            ["@babel/plugin-syntax-typescript", "virtual:bcd7c93c8801fd258e0ad62676110ca91947d5f855189c47b4245169dc84b36adc535e9c1ec60f9722dbf3c5fef0b1f02cb9277b8abcb7de0f69c11840775828#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2714,10 +2542,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-unicode-escapes", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-unicode-escapes-virtual-046fc4fd3d/4/.yarncache/berry/cache/@babel-plugin-transform-unicode-escapes-npm-7.10.1-451c577805-2.zip/node_modules/@babel/plugin-transform-unicode-escapes/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-unicode-escapes-virtual-4be3b79875/4/.yarncache/berry/cache/@babel-plugin-transform-unicode-escapes-npm-7.10.1-451c577805-2.zip/node_modules/@babel/plugin-transform-unicode-escapes/",
           "packageDependencies": [
-            ["@babel/plugin-transform-unicode-escapes", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-unicode-escapes", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
@@ -2728,19 +2556,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-transform-unicode-regex", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-unicode-regex-virtual-62107315ae/4/.yarncache/berry/cache/@babel-plugin-transform-unicode-regex-npm-7.10.1-8517b4cbc3-2.zip/node_modules/@babel/plugin-transform-unicode-regex/",
-          "packageDependencies": [
-            ["@babel/plugin-transform-unicode-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-create-regexp-features-plugin", "virtual:9c49dc8da71cec43a660f2958f0f1f311bb7662b7e19e7f70a1586dea8e1f156be228a1872e8d06ed1d2d7fc5051cd177bb87f2c11fd580e56b70bfdd18cde77#npm:7.10.1"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-unicode-regex-virtual-58c9411ca1/4/.yarncache/berry/cache/@babel-plugin-transform-unicode-regex-npm-7.8.3-d2aba93d5b-2.zip/node_modules/@babel/plugin-transform-unicode-regex/",
           "packageDependencies": [
@@ -2748,6 +2563,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-create-regexp-features-plugin", "virtual:6be1a752b3e6318fc833d784b94c6163f4c0b5531f2374e8fc0f8d39ff1ff0e98b3bc5a078386e119b6ee785aa47aae39825ee36a7d5fe7c765d835f5212252a#npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-unicode-regex-virtual-0fd6fc4b7f/4/.yarncache/berry/cache/@babel-plugin-transform-unicode-regex-npm-7.10.1-8517b4cbc3-2.zip/node_modules/@babel/plugin-transform-unicode-regex/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-unicode-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-create-regexp-features-plugin", "virtual:cb8f80b61844cfdb1368d4bef351f30e068e6bd6d28b5a6ae078016a4ca8ce939c7f9c144ed8da631f977730ffe43f4be84ec10ceda87dd1b380ed16e0eedb05#npm:7.10.1"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2767,81 +2595,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/preset-env", [
-        ["virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.2", {
-          "packageLocation": "./.yarn/$$virtual/@babel-preset-env-virtual-474c854e07/4/.yarncache/berry/cache/@babel-preset-env-npm-7.10.2-bb305184fd-2.zip/node_modules/@babel/preset-env/",
-          "packageDependencies": [
-            ["@babel/preset-env", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.2"],
-            ["@babel/compat-data", "npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-compilation-targets", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.2"],
-            ["@babel/helper-module-imports", "npm:7.10.1"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-proposal-async-generator-functions", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-class-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-dynamic-import", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
-            ["@babel/plugin-proposal-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-object-rest-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-optional-catch-binding", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-optional-chaining", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
-            ["@babel/plugin-proposal-private-methods", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-unicode-property-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-syntax-async-generators", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.4"],
-            ["@babel/plugin-syntax-class-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
-            ["@babel/plugin-syntax-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
-            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:eed8eeef4910a2fcdb369cf67775b18fc345b7294b5ee2549a66416f0d97cd1003c839c34213098e4a5c3be0f62d7648e0f42f38c5636f9ee1c6be7865f11c6d#npm:7.8.3"],
-            ["@babel/plugin-syntax-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-syntax-object-rest-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
-            ["@babel/plugin-syntax-optional-catch-binding", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
-            ["@babel/plugin-syntax-optional-chaining", "virtual:a84042cba769adb2e1a20888b5e698e93cdbacbd22d935dc93f12c2edae767e12e2ccb5fd7b839d2fdda56ac7f51361d3452737fd289b63ec372aefdb263ee48#npm:7.8.3"],
-            ["@babel/plugin-syntax-top-level-await", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-arrow-functions", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-async-to-generator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-block-scoped-functions", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-block-scoping", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-classes", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-computed-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-destructuring", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-dotall-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-duplicate-keys", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-exponentiation-operator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-for-of", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-function-name", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-member-expression-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-modules-amd", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-modules-commonjs", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-modules-systemjs", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-modules-umd", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-named-capturing-groups-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
-            ["@babel/plugin-transform-new-target", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-object-super", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-parameters", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-property-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-regenerator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-reserved-words", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-shorthand-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-sticky-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-template-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-typeof-symbol", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-unicode-escapes", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-unicode-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/preset-modules", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:0.1.3"],
-            ["@babel/types", "npm:7.10.2"],
-            ["browserslist", "npm:4.12.0"],
-            ["core-js-compat", "npm:3.6.4"],
-            ["invariant", "npm:2.2.4"],
-            ["levenary", "npm:1.1.1"],
-            ["semver", "npm:5.7.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:2ceb4517298ac0ac865b67630b09dbd12ce833d767bf3f69c8877bfcc9911d47df368a52689e47616990fc75abebc9a356eb981a9665ae81bc2c7516cedb8735#npm:7.8.6", {
           "packageLocation": "./.yarn/$$virtual/@babel-preset-env-virtual-8b4e5b25c4/4/.yarncache/berry/cache/@babel-preset-env-npm-7.8.6-54087a2c02-2.zip/node_modules/@babel/preset-env/",
           "packageDependencies": [
@@ -2916,63 +2669,63 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/preset-env", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
             ["@babel/compat-data", "npm:7.10.3"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-compilation-targets", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.2"],
+            ["@babel/helper-compilation-targets", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.2"],
             ["@babel/helper-module-imports", "npm:7.10.3"],
             ["@babel/helper-plugin-utils", "npm:7.10.3"],
             ["@babel/plugin-proposal-async-generator-functions", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
-            ["@babel/plugin-proposal-class-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-dynamic-import", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-class-properties", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-proposal-dynamic-import", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-proposal-json-strings", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
-            ["@babel/plugin-proposal-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-numeric-separator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/plugin-proposal-object-rest-spread", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
-            ["@babel/plugin-proposal-optional-catch-binding", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-optional-catch-binding", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/plugin-proposal-optional-chaining", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
-            ["@babel/plugin-proposal-private-methods", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-unicode-property-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-syntax-async-generators", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.4"],
-            ["@babel/plugin-syntax-class-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-private-methods", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-proposal-unicode-property-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-syntax-async-generators", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.4"],
+            ["@babel/plugin-syntax-class-properties", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
-            ["@babel/plugin-syntax-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
-            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:eed8eeef4910a2fcdb369cf67775b18fc345b7294b5ee2549a66416f0d97cd1003c839c34213098e4a5c3be0f62d7648e0f42f38c5636f9ee1c6be7865f11c6d#npm:7.8.3"],
-            ["@babel/plugin-syntax-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-syntax-object-rest-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
-            ["@babel/plugin-syntax-optional-catch-binding", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
-            ["@babel/plugin-syntax-optional-chaining", "virtual:a84042cba769adb2e1a20888b5e698e93cdbacbd22d935dc93f12c2edae767e12e2ccb5fd7b839d2fdda56ac7f51361d3452737fd289b63ec372aefdb263ee48#npm:7.8.3"],
-            ["@babel/plugin-syntax-top-level-await", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-arrow-functions", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-async-to-generator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-block-scoped-functions", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-block-scoping", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-syntax-json-strings", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3"],
+            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:6366cea8102b4b975891233f0336637b165f817687d86205582a902f3469fded79adf2e2cccd9f9d588e769df97dfc106b124470b2b96fef02858f93d3826038#npm:7.8.3"],
+            ["@babel/plugin-syntax-numeric-separator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-syntax-object-rest-spread", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-catch-binding", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-chaining", "virtual:b6aaf2ac4c489c15fd3dbc77810a8926f96c5c2f3dc2d656e0980d39c50f0db3613531e235e2c4a52eeeeae552daa809caf802f959aea2f43bebb00cb787ecd3#npm:7.8.3"],
+            ["@babel/plugin-syntax-top-level-await", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-arrow-functions", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-async-to-generator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-block-scoped-functions", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-block-scoping", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/plugin-transform-classes", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
             ["@babel/plugin-transform-computed-properties", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
-            ["@babel/plugin-transform-destructuring", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-dotall-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-duplicate-keys", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-exponentiation-operator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-for-of", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-function-name", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-member-expression-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-modules-amd", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-modules-commonjs", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-destructuring", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-dotall-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-duplicate-keys", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-exponentiation-operator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-for-of", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-function-name", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-literals", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-member-expression-literals", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-modules-amd", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-modules-commonjs", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/plugin-transform-modules-systemjs", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
-            ["@babel/plugin-transform-modules-umd", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-modules-umd", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/plugin-transform-named-capturing-groups-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
-            ["@babel/plugin-transform-new-target", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-object-super", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-parameters", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-property-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-new-target", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-object-super", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-parameters", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-property-literals", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/plugin-transform-regenerator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
-            ["@babel/plugin-transform-reserved-words", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-shorthand-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-sticky-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-reserved-words", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-shorthand-properties", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-spread", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-sticky-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/plugin-transform-template-literals", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
-            ["@babel/plugin-transform-typeof-symbol", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-unicode-escapes", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-unicode-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/preset-modules", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:0.1.3"],
+            ["@babel/plugin-transform-typeof-symbol", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-unicode-escapes", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-unicode-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/preset-modules", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:0.1.3"],
             ["@babel/types", "npm:7.10.3"],
             ["browserslist", "npm:4.12.0"],
             ["core-js-compat", "npm:3.6.4"],
@@ -2993,7 +2746,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/preset-flow", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-transform-flow-strip-types", "virtual:3de52e135f6b931c379d710a63f060759811b923879cb7aaab78d3eebb01fd1bd2463208cae513a126de66039c841eb067d82925208875be3a99cd629465d431#npm:7.10.1"]
+            ["@babel/plugin-transform-flow-strip-types", "virtual:94794d58f84ad87e928143cc6326a93430b89c3f7792598aa4eb46bc3903ec039939f0c3d17ffbb857dca4078e8e1619111d0b93a2db11e2fff59ff3db4ea78e#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -3002,14 +2755,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/preset-modules", [
-        ["virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:0.1.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-preset-modules-virtual-f1bec78d4a/4/.yarncache/berry/cache/@babel-preset-modules-npm-0.1.3-d63a86113f-2.zip/node_modules/@babel/preset-modules/",
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:0.1.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-preset-modules-virtual-d30dbb89ba/4/.yarncache/berry/cache/@babel-preset-modules-npm-0.1.3-d63a86113f-2.zip/node_modules/@babel/preset-modules/",
           "packageDependencies": [
-            ["@babel/preset-modules", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:0.1.3"],
+            ["@babel/preset-modules", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:0.1.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-proposal-unicode-property-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-transform-dotall-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-unicode-property-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
+            ["@babel/plugin-transform-dotall-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.1"],
             ["@babel/types", "npm:7.10.2"],
             ["esutils", "npm:2.0.3"]
           ],
@@ -3042,12 +2795,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/preset-react", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-transform-react-display-name", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
-            ["@babel/plugin-transform-react-jsx", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
-            ["@babel/plugin-transform-react-jsx-development", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
-            ["@babel/plugin-transform-react-jsx-self", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
-            ["@babel/plugin-transform-react-jsx-source", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
-            ["@babel/plugin-transform-react-pure-annotations", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"]
+            ["@babel/plugin-transform-react-display-name", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx-development", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx-self", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx-source", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"],
+            ["@babel/plugin-transform-react-pure-annotations", "virtual:efba1491e7a324721581d2c0abd9c498d3edd7b39565f4141900a944b947d4a9e2d43f5f1f5d8ed0237c4bdee31023787abf902c8d3dd7635a765e221a7138f7#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -4974,29 +4727,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-plugin-macros", "npm:2.8.0"],
             ["babel-plugin-transform-react-remove-prop-types", "npm:0.4.24"],
             ["gatsby-core-utils", "npm:1.0.28"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }]
-      ]],
-      ["babel-preset-gatsby-package", [
-        ["virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.4", {
-          "packageLocation": "./.yarn/$$virtual/babel-preset-gatsby-package-virtual-0665bdba0c/4/.yarncache/berry/cache/babel-preset-gatsby-package-npm-0.4.4-98d69f86f8-2.zip/node_modules/babel-preset-gatsby-package/",
-          "packageDependencies": [
-            ["babel-preset-gatsby-package", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.4"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
-            ["@babel/plugin-proposal-optional-chaining", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
-            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
-            ["@babel/plugin-transform-runtime", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
-            ["@babel/plugin-transform-typescript", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
-            ["@babel/preset-env", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.2"],
-            ["@babel/preset-flow", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
-            ["@babel/preset-react", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
-            ["babel-plugin-dynamic-import-node", "npm:2.3.3"],
-            ["core-js", "npm:2.6.11"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -9122,7 +8852,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/typescript-estree", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.21.0"],
             ["@yarnpkg/pnpify", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.0.0-rc.18"],
             ["babel-plugin-dynamic-import-node", "npm:2.3.3"],
-            ["babel-preset-gatsby-package", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.4"],
             ["eslint", "npm:6.8.0"],
             ["fs-extra", "npm:8.1.0"],
             ["gatsby", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.19.23"],

--- a/.pnp.js
+++ b/.pnp.js
@@ -36,6 +36,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./",
           "packageDependencies": [
             ["@babel/core", "npm:7.8.6"],
+            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
+            ["@babel/plugin-proposal-optional-chaining", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
+            ["@babel/plugin-transform-runtime", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/plugin-transform-typescript", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/preset-env", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/preset-flow", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
+            ["@babel/preset-react", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
             ["@babel/preset-typescript", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
             ["@babel/register", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.6"],
             ["@babel/runtime", "npm:7.8.7"],
@@ -49,6 +57,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/parser", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.21.0"],
             ["@typescript-eslint/typescript-estree", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.21.0"],
             ["@yarnpkg/pnpify", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.0.0-rc.18"],
+            ["babel-plugin-dynamic-import-node", "npm:2.3.3"],
             ["babel-preset-gatsby-package", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.4"],
             ["eslint", "npm:6.8.0"],
             ["fs-extra", "npm:8.1.0"],
@@ -80,6 +89,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-code-frame-npm-7.10.3-fc24f45b28-2.zip/node_modules/@babel/code-frame/",
+          "packageDependencies": [
+            ["@babel/code-frame", "npm:7.10.3"],
+            ["@babel/highlight", "npm:7.10.3"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:7.8.3", {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-code-frame-npm-7.8.3-ea28dc5d9b-2.zip/node_modules/@babel/code-frame/",
           "packageDependencies": [
@@ -94,6 +111,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-compat-data-npm-7.10.1-decc33e22f-2.zip/node_modules/@babel/compat-data/",
           "packageDependencies": [
             ["@babel/compat-data", "npm:7.10.1"],
+            ["browserslist", "npm:4.12.0"],
+            ["invariant", "npm:2.2.4"],
+            ["semver", "npm:5.7.1"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-compat-data-npm-7.10.3-e2f2694333-2.zip/node_modules/@babel/compat-data/",
+          "packageDependencies": [
+            ["@babel/compat-data", "npm:7.10.3"],
             ["browserslist", "npm:4.12.0"],
             ["invariant", "npm:2.2.4"],
             ["semver", "npm:5.7.1"]
@@ -141,6 +168,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/generator", "npm:7.10.2"],
             ["@babel/types", "npm:7.10.2"],
+            ["jsesc", "npm:2.5.2"],
+            ["lodash", "npm:4.17.15"],
+            ["source-map", "npm:0.5.7"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-generator-npm-7.10.3-760bb34bd6-2.zip/node_modules/@babel/generator/",
+          "packageDependencies": [
+            ["@babel/generator", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"],
             ["jsesc", "npm:2.5.2"],
             ["lodash", "npm:4.17.15"],
             ["source-map", "npm:0.5.7"]
@@ -326,6 +364,23 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:bcd7c93c8801fd258e0ad62676110ca91947d5f855189c47b4245169dc84b36adc535e9c1ec60f9722dbf3c5fef0b1f02cb9277b8abcb7de0f69c11840775828#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-helper-create-class-features-plugin-virtual-ca878a648f/4/.yarncache/berry/cache/@babel-helper-create-class-features-plugin-npm-7.10.3-ec91e539c5-2.zip/node_modules/@babel/helper-create-class-features-plugin/",
+          "packageDependencies": [
+            ["@babel/helper-create-class-features-plugin", "virtual:bcd7c93c8801fd258e0ad62676110ca91947d5f855189c47b4245169dc84b36adc535e9c1ec60f9722dbf3c5fef0b1f02cb9277b8abcb7de0f69c11840775828#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-function-name", "npm:7.10.3"],
+            ["@babel/helper-member-expression-to-functions", "npm:7.10.3"],
+            ["@babel/helper-optimise-call-expression", "npm:7.10.3"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"],
+            ["@babel/helper-replace-supers", "npm:7.10.1"],
+            ["@babel/helper-split-export-declaration", "npm:7.10.1"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/helper-create-regexp-features-plugin", [
@@ -383,6 +438,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-define-map-npm-7.10.3-3b7c7666e5-2.zip/node_modules/@babel/helper-define-map/",
+          "packageDependencies": [
+            ["@babel/helper-define-map", "npm:7.10.3"],
+            ["@babel/helper-function-name", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"],
+            ["lodash", "npm:4.17.15"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:7.8.3", {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-define-map-npm-7.8.3-3e85f6abac-2.zip/node_modules/@babel/helper-define-map/",
           "packageDependencies": [
@@ -425,6 +490,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-function-name-npm-7.10.3-7b9c45a3e6-2.zip/node_modules/@babel/helper-function-name/",
+          "packageDependencies": [
+            ["@babel/helper-function-name", "npm:7.10.3"],
+            ["@babel/helper-get-function-arity", "npm:7.10.3"],
+            ["@babel/template", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:7.8.3", {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-function-name-npm-7.8.3-77f74a8fe8-2.zip/node_modules/@babel/helper-function-name/",
           "packageDependencies": [
@@ -442,6 +517,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/helper-get-function-arity", "npm:7.10.1"],
             ["@babel/types", "npm:7.10.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-get-function-arity-npm-7.10.3-c99d7ea6e3-2.zip/node_modules/@babel/helper-get-function-arity/",
+          "packageDependencies": [
+            ["@babel/helper-get-function-arity", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"]
           ],
           "linkType": "HARD",
         }],
@@ -463,6 +546,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-hoist-variables-npm-7.10.3-3f418a8829-2.zip/node_modules/@babel/helper-hoist-variables/",
+          "packageDependencies": [
+            ["@babel/helper-hoist-variables", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:7.8.3", {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-hoist-variables-npm-7.8.3-6031c194ad-2.zip/node_modules/@babel/helper-hoist-variables/",
           "packageDependencies": [
@@ -481,6 +572,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-member-expression-to-functions-npm-7.10.3-bdcebec797-2.zip/node_modules/@babel/helper-member-expression-to-functions/",
+          "packageDependencies": [
+            ["@babel/helper-member-expression-to-functions", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:7.8.3", {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-member-expression-to-functions-npm-7.8.3-0786a7806f-2.zip/node_modules/@babel/helper-member-expression-to-functions/",
           "packageDependencies": [
@@ -496,6 +595,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/helper-module-imports", "npm:7.10.1"],
             ["@babel/types", "npm:7.10.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-module-imports-npm-7.10.3-29c51cdb8f-2.zip/node_modules/@babel/helper-module-imports/",
+          "packageDependencies": [
+            ["@babel/helper-module-imports", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"]
           ],
           "linkType": "HARD",
         }],
@@ -547,6 +654,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-optimise-call-expression-npm-7.10.3-6bcae4ca7d-2.zip/node_modules/@babel/helper-optimise-call-expression/",
+          "packageDependencies": [
+            ["@babel/helper-optimise-call-expression", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:7.8.3", {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-optimise-call-expression-npm-7.8.3-864828ebe3-2.zip/node_modules/@babel/helper-optimise-call-expression/",
           "packageDependencies": [
@@ -561,6 +676,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-plugin-utils-npm-7.10.1-c8f8e50ea8-2.zip/node_modules/@babel/helper-plugin-utils/",
           "packageDependencies": [
             ["@babel/helper-plugin-utils", "npm:7.10.1"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-plugin-utils-npm-7.10.3-1e377eedda-2.zip/node_modules/@babel/helper-plugin-utils/",
+          "packageDependencies": [
+            ["@babel/helper-plugin-utils", "npm:7.10.3"]
           ],
           "linkType": "HARD",
         }],
@@ -600,6 +722,18 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/template", "npm:7.10.1"],
             ["@babel/traverse", "npm:7.10.1"],
             ["@babel/types", "npm:7.10.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-remap-async-to-generator-npm-7.10.3-9688db0269-2.zip/node_modules/@babel/helper-remap-async-to-generator/",
+          "packageDependencies": [
+            ["@babel/helper-remap-async-to-generator", "npm:7.10.3"],
+            ["@babel/helper-annotate-as-pure", "npm:7.10.1"],
+            ["@babel/helper-wrap-function", "npm:7.10.1"],
+            ["@babel/template", "npm:7.10.3"],
+            ["@babel/traverse", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"]
           ],
           "linkType": "HARD",
         }],
@@ -685,6 +819,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/helper-validator-identifier", "npm:7.10.1"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-helper-validator-identifier-npm-7.10.3-cb3830e4b0-2.zip/node_modules/@babel/helper-validator-identifier/",
+          "packageDependencies": [
+            ["@babel/helper-validator-identifier", "npm:7.10.3"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/helper-wrap-function", [
@@ -734,6 +875,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-highlight-npm-7.10.3-f2625e428b-2.zip/node_modules/@babel/highlight/",
+          "packageDependencies": [
+            ["@babel/highlight", "npm:7.10.3"],
+            ["@babel/helper-validator-identifier", "npm:7.10.3"],
+            ["chalk", "npm:2.4.2"],
+            ["js-tokens", "npm:4.0.0"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:7.8.3", {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-highlight-npm-7.8.3-7222e70eb1-2.zip/node_modules/@babel/highlight/",
           "packageDependencies": [
@@ -750,6 +901,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-parser-npm-7.10.2-5b2329500e-2.zip/node_modules/@babel/parser/",
           "packageDependencies": [
             ["@babel/parser", "npm:7.10.2"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-parser-npm-7.10.3-abbba6b4aa-2.zip/node_modules/@babel/parser/",
+          "packageDependencies": [
+            ["@babel/parser", "npm:7.10.3"]
           ],
           "linkType": "HARD",
         }],
@@ -784,6 +942,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/helper-plugin-utils", "npm:7.8.3"],
             ["@babel/helper-remap-async-to-generator", "npm:7.8.3"],
             ["@babel/plugin-syntax-async-generators", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.4"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-async-generator-functions-virtual-ba595437e9/4/.yarncache/berry/cache/@babel-plugin-proposal-async-generator-functions-npm-7.10.3-fe3c879131-2.zip/node_modules/@babel/plugin-proposal-async-generator-functions/",
+          "packageDependencies": [
+            ["@babel/plugin-proposal-async-generator-functions", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"],
+            ["@babel/helper-remap-async-to-generator", "npm:7.10.3"],
+            ["@babel/plugin-syntax-async-generators", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.4"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -826,7 +998,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/plugin-proposal-dynamic-import", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-dynamic-import", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.8.3"]
+            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -876,19 +1048,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-proposal-nullish-coalescing-operator", [
-        ["virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-nullish-coalescing-operator-virtual-eed8eeef49/4/.yarncache/berry/cache/@babel-plugin-proposal-nullish-coalescing-operator-npm-7.10.1-0f7f2c1049-2.zip/node_modules/@babel/plugin-proposal-nullish-coalescing-operator/",
-          "packageDependencies": [
-            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:eed8eeef4910a2fcdb369cf67775b18fc345b7294b5ee2549a66416f0d97cd1003c839c34213098e4a5c3be0f62d7648e0f42f38c5636f9ee1c6be7865f11c6d#npm:7.8.3"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:2ceb4517298ac0ac865b67630b09dbd12ce833d767bf3f69c8877bfcc9911d47df368a52689e47616990fc75abebc9a356eb981a9665ae81bc2c7516cedb8735#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-nullish-coalescing-operator-virtual-fb5c0e4f03/4/.yarncache/berry/cache/@babel-plugin-proposal-nullish-coalescing-operator-npm-7.8.3-05e97adf4e-2.zip/node_modules/@babel/plugin-proposal-nullish-coalescing-operator/",
           "packageDependencies": [
@@ -896,6 +1055,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"],
             ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:fb5c0e4f036a99f173327cbdf2dee76843522513a83c18b5a8ccd306ee5025bd7291eae77a82dd82d54fff8e55adc5b660feb693aacba04daa4b2b079120ac2d#npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-nullish-coalescing-operator-virtual-6366cea810/4/.yarncache/berry/cache/@babel-plugin-proposal-nullish-coalescing-operator-npm-7.10.1-0f7f2c1049-2.zip/node_modules/@babel/plugin-proposal-nullish-coalescing-operator/",
+          "packageDependencies": [
+            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"],
+            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:eed8eeef4910a2fcdb369cf67775b18fc345b7294b5ee2549a66416f0d97cd1003c839c34213098e4a5c3be0f62d7648e0f42f38c5636f9ee1c6be7865f11c6d#npm:7.8.3"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -940,6 +1112,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"],
             ["@babel/plugin-syntax-object-rest-spread", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-object-rest-spread-virtual-4f6e192520/4/.yarncache/berry/cache/@babel-plugin-proposal-object-rest-spread-npm-7.10.3-d5d33fe9ac-2.zip/node_modules/@babel/plugin-proposal-object-rest-spread/",
+          "packageDependencies": [
+            ["@babel/plugin-proposal-object-rest-spread", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"],
+            ["@babel/plugin-syntax-object-rest-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
+            ["@babel/plugin-transform-parameters", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -996,6 +1182,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"],
             ["@babel/plugin-syntax-optional-chaining", "virtual:2bd503069b41802f90b8dbc130d91e234d3b5b635b9eb6fb6b6d44c977ec73ba99c7fb58a9f66ae43639d99d55053bf96111ca99aa3bfe421600e299bbad0d5d#npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-proposal-optional-chaining-virtual-b6aaf2ac4c/4/.yarncache/berry/cache/@babel-plugin-proposal-optional-chaining-npm-7.10.3-7329225910-2.zip/node_modules/@babel/plugin-proposal-optional-chaining/",
+          "packageDependencies": [
+            ["@babel/plugin-proposal-optional-chaining", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"],
+            ["@babel/plugin-syntax-optional-chaining", "virtual:a84042cba769adb2e1a20888b5e698e93cdbacbd22d935dc93f12c2edae767e12e2ccb5fd7b839d2fdda56ac7f51361d3452737fd289b63ec372aefdb263ee48#npm:7.8.3"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -1087,10 +1286,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/plugin-syntax-dynamic-import", [
-        ["virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.8.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-dynamic-import-virtual-b839dc6015/4/.yarncache/berry/cache/@babel-plugin-syntax-dynamic-import-npm-7.8.3-fb9ff5634a-2.zip/node_modules/@babel/plugin-syntax-dynamic-import/",
+        ["virtual:2ceb4517298ac0ac865b67630b09dbd12ce833d767bf3f69c8877bfcc9911d47df368a52689e47616990fc75abebc9a356eb981a9665ae81bc2c7516cedb8735#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-dynamic-import-virtual-2a11327d14/4/.yarncache/berry/cache/@babel-plugin-syntax-dynamic-import-npm-7.8.3-fb9ff5634a-2.zip/node_modules/@babel/plugin-syntax-dynamic-import/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-dynamic-import", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.8.3"],
+            ["@babel/plugin-syntax-dynamic-import", "virtual:2ceb4517298ac0ac865b67630b09dbd12ce833d767bf3f69c8877bfcc9911d47df368a52689e47616990fc75abebc9a356eb981a9665ae81bc2c7516cedb8735#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
           ],
@@ -1099,10 +1298,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
-        ["virtual:2ceb4517298ac0ac865b67630b09dbd12ce833d767bf3f69c8877bfcc9911d47df368a52689e47616990fc75abebc9a356eb981a9665ae81bc2c7516cedb8735#npm:7.8.3", {
-          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-dynamic-import-virtual-2a11327d14/4/.yarncache/berry/cache/@babel-plugin-syntax-dynamic-import-npm-7.8.3-fb9ff5634a-2.zip/node_modules/@babel/plugin-syntax-dynamic-import/",
+        ["virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-syntax-dynamic-import-virtual-3d82768ab4/4/.yarncache/berry/cache/@babel-plugin-syntax-dynamic-import-npm-7.8.3-fb9ff5634a-2.zip/node_modules/@babel/plugin-syntax-dynamic-import/",
           "packageDependencies": [
-            ["@babel/plugin-syntax-dynamic-import", "virtual:2ceb4517298ac0ac865b67630b09dbd12ce833d767bf3f69c8877bfcc9911d47df368a52689e47616990fc75abebc9a356eb981a9665ae81bc2c7516cedb8735#npm:7.8.3"],
+            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
           ],
@@ -1496,6 +1695,25 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-classes-virtual-87a86b3d5c/4/.yarncache/berry/cache/@babel-plugin-transform-classes-npm-7.10.3-eb6de7ae93-2.zip/node_modules/@babel/plugin-transform-classes/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-classes", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-annotate-as-pure", "npm:7.10.1"],
+            ["@babel/helper-define-map", "npm:7.10.3"],
+            ["@babel/helper-function-name", "npm:7.10.3"],
+            ["@babel/helper-optimise-call-expression", "npm:7.10.3"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"],
+            ["@babel/helper-replace-supers", "npm:7.10.1"],
+            ["@babel/helper-split-export-declaration", "npm:7.10.1"],
+            ["globals", "npm:11.12.0"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-transform-computed-properties", [
@@ -1517,6 +1735,18 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/plugin-transform-computed-properties", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-computed-properties-virtual-c3d8005635/4/.yarncache/berry/cache/@babel-plugin-transform-computed-properties-npm-7.10.3-5d5a287332-2.zip/node_modules/@babel/plugin-transform-computed-properties/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-computed-properties", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -1845,6 +2075,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-modules-systemjs-virtual-606119b420/4/.yarncache/berry/cache/@babel-plugin-transform-modules-systemjs-npm-7.10.3-13d4862fcb-2.zip/node_modules/@babel/plugin-transform-modules-systemjs/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-modules-systemjs", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-hoist-variables", "npm:7.10.3"],
+            ["@babel/helper-module-transforms", "npm:7.10.1"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"],
+            ["babel-plugin-dynamic-import-node", "npm:2.3.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-transform-modules-umd", [
@@ -1894,6 +2139,18 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/plugin-transform-named-capturing-groups-regex", "virtual:8b4e5b25c456881ccd9133098b1f3882573348989791b0e117070a56ffc3cb59adec8c48515a5729d501b193fc2b7eb3eceac27a0deae95494d66eb763f9e2a7#npm:7.8.3"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-create-regexp-features-plugin", "virtual:6be1a752b3e6318fc833d784b94c6163f4c0b5531f2374e8fc0f8d39ff1ff0e98b3bc5a078386e119b6ee785aa47aae39825ee36a7d5fe7c765d835f5212252a#npm:7.8.6"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-named-capturing-groups-regex-virtual-50f975f857/4/.yarncache/berry/cache/@babel-plugin-transform-named-capturing-groups-regex-npm-7.10.3-9d84ca4bee-2.zip/node_modules/@babel/plugin-transform-named-capturing-groups-regex/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-named-capturing-groups-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-create-regexp-features-plugin", "virtual:1120c66e38adff9979f67f86ce6b7edd627879c20f265b980ac89f877f836fb4605ec49465b7034da6a10dad2fdd19c2868176e1945a9635a3c5f9b32d8260f2#npm:7.8.6"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2178,6 +2435,18 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-regenerator-virtual-657f6e9bdd/4/.yarncache/berry/cache/@babel-plugin-transform-regenerator-npm-7.10.3-3d9e7a2b7f-2.zip/node_modules/@babel/plugin-transform-regenerator/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-regenerator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["regenerator-transform", "npm:0.14.4"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-transform-reserved-words", [
@@ -2229,6 +2498,21 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-module-imports", "npm:7.8.3"],
             ["@babel/helper-plugin-utils", "npm:7.8.3"],
+            ["resolve", "patch:resolve@npm%3A1.15.1#builtin<compat/resolve>::version=1.15.1&hash=8fccd0"],
+            ["semver", "npm:5.7.1"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-runtime-virtual-404633e881/4/.yarncache/berry/cache/@babel-plugin-transform-runtime-npm-7.10.3-e24f6f64ca-2.zip/node_modules/@babel/plugin-transform-runtime/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-runtime", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-module-imports", "npm:7.10.3"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"],
             ["resolve", "patch:resolve@npm%3A1.15.1#builtin<compat/resolve>::version=1.15.1&hash=8fccd0"],
             ["semver", "npm:5.7.1"]
           ],
@@ -2344,6 +2628,19 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-template-literals-virtual-fdef5e79b7/4/.yarncache/berry/cache/@babel-plugin-transform-template-literals-npm-7.10.3-80a959758e-2.zip/node_modules/@babel/plugin-transform-template-literals/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-template-literals", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-annotate-as-pure", "npm:7.10.1"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/plugin-transform-typeof-symbol", [
@@ -2394,6 +2691,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-create-class-features-plugin", "virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.2"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
+            ["@babel/plugin-syntax-typescript", "virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.1"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-plugin-transform-typescript-virtual-bcd7c93c88/4/.yarncache/berry/cache/@babel-plugin-transform-typescript-npm-7.10.3-1fc170ba2e-2.zip/node_modules/@babel/plugin-transform-typescript/",
+          "packageDependencies": [
+            ["@babel/plugin-transform-typescript", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-create-class-features-plugin", "virtual:bcd7c93c8801fd258e0ad62676110ca91947d5f855189c47b4245169dc84b36adc535e9c1ec60f9722dbf3c5fef0b1f02cb9277b8abcb7de0f69c11840775828#npm:7.10.3"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"],
             ["@babel/plugin-syntax-typescript", "virtual:5e782ca4d5040fb54c7b0a66cb79cc21f60227a3487eb1aa8adc86098496061993ebef4a6e011c74513978557e69b126a8579cf0e6eea9b6ebe3dd9c4867d764#npm:7.10.1"]
           ],
           "packagePeers": [
@@ -2469,7 +2780,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/plugin-proposal-class-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
             ["@babel/plugin-proposal-dynamic-import", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
             ["@babel/plugin-proposal-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
+            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
             ["@babel/plugin-proposal-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
             ["@babel/plugin-proposal-object-rest-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
             ["@babel/plugin-proposal-optional-catch-binding", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
@@ -2478,7 +2789,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/plugin-proposal-unicode-property-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
             ["@babel/plugin-syntax-async-generators", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.4"],
             ["@babel/plugin-syntax-class-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
-            ["@babel/plugin-syntax-dynamic-import", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.8.3"],
+            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
             ["@babel/plugin-syntax-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
             ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:eed8eeef4910a2fcdb369cf67775b18fc345b7294b5ee2549a66416f0d97cd1003c839c34213098e4a5c3be0f62d7648e0f42f38c5636f9ee1c6be7865f11c6d#npm:7.8.3"],
             ["@babel/plugin-syntax-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
@@ -2598,13 +2909,88 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "@babel/core"
           ],
           "linkType": "HARD",
+        }],
+        ["virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3", {
+          "packageLocation": "./.yarn/$$virtual/@babel-preset-env-virtual-8e74c37334/4/.yarncache/berry/cache/@babel-preset-env-npm-7.10.3-da642b9e85-2.zip/node_modules/@babel/preset-env/",
+          "packageDependencies": [
+            ["@babel/preset-env", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/compat-data", "npm:7.10.3"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-compilation-targets", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.2"],
+            ["@babel/helper-module-imports", "npm:7.10.3"],
+            ["@babel/helper-plugin-utils", "npm:7.10.3"],
+            ["@babel/plugin-proposal-async-generator-functions", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/plugin-proposal-class-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-dynamic-import", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
+            ["@babel/plugin-proposal-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-object-rest-spread", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/plugin-proposal-optional-catch-binding", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-optional-chaining", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/plugin-proposal-private-methods", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-proposal-unicode-property-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-syntax-async-generators", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.4"],
+            ["@babel/plugin-syntax-class-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
+            ["@babel/plugin-syntax-json-strings", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
+            ["@babel/plugin-syntax-nullish-coalescing-operator", "virtual:eed8eeef4910a2fcdb369cf67775b18fc345b7294b5ee2549a66416f0d97cd1003c839c34213098e4a5c3be0f62d7648e0f42f38c5636f9ee1c6be7865f11c6d#npm:7.8.3"],
+            ["@babel/plugin-syntax-numeric-separator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-syntax-object-rest-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-catch-binding", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.8.3"],
+            ["@babel/plugin-syntax-optional-chaining", "virtual:a84042cba769adb2e1a20888b5e698e93cdbacbd22d935dc93f12c2edae767e12e2ccb5fd7b839d2fdda56ac7f51361d3452737fd289b63ec372aefdb263ee48#npm:7.8.3"],
+            ["@babel/plugin-syntax-top-level-await", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-arrow-functions", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-async-to-generator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-block-scoped-functions", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-block-scoping", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-classes", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/plugin-transform-computed-properties", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/plugin-transform-destructuring", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-dotall-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-duplicate-keys", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-exponentiation-operator", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-for-of", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-function-name", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-member-expression-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-modules-amd", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-modules-commonjs", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-modules-systemjs", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/plugin-transform-modules-umd", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-named-capturing-groups-regex", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/plugin-transform-new-target", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-object-super", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-parameters", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-property-literals", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-regenerator", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/plugin-transform-reserved-words", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-shorthand-properties", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-spread", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-sticky-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-template-literals", "virtual:8e74c373341c9e312294e7c35c5d57b2410ba4ef4c7e7b1645426745e0d83bed7e1f33e9a175ac95224359198f0f835af94a9e0240f7555b69602a5dd5bcfaa1#npm:7.10.3"],
+            ["@babel/plugin-transform-typeof-symbol", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-unicode-escapes", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/plugin-transform-unicode-regex", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:7.10.1"],
+            ["@babel/preset-modules", "virtual:474c854e0725bd45001555d778b56075439ea436abc003cd00ceca0b8e32cc75b149609c1d829defbb364cb93527b7598c0037bccabc5120ba3ff0b2ee841492#npm:0.1.3"],
+            ["@babel/types", "npm:7.10.3"],
+            ["browserslist", "npm:4.12.0"],
+            ["core-js-compat", "npm:3.6.4"],
+            ["invariant", "npm:2.2.4"],
+            ["levenary", "npm:1.1.1"],
+            ["semver", "npm:5.7.1"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["@babel/preset-flow", [
-        ["virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-preset-flow-virtual-3de52e135f/4/.yarncache/berry/cache/@babel-preset-flow-npm-7.10.1-46008615c9-2.zip/node_modules/@babel/preset-flow/",
+        ["virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-preset-flow-virtual-94794d58f8/4/.yarncache/berry/cache/@babel-preset-flow-npm-7.10.1-46008615c9-2.zip/node_modules/@babel/preset-flow/",
           "packageDependencies": [
-            ["@babel/preset-flow", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
+            ["@babel/preset-flow", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
             ["@babel/core", "npm:7.8.6"],
             ["@babel/helper-plugin-utils", "npm:7.10.1"],
             ["@babel/plugin-transform-flow-strip-types", "virtual:3de52e135f6b931c379d710a63f060759811b923879cb7aaab78d3eebb01fd1bd2463208cae513a126de66039c841eb067d82925208875be3a99cd629465d431#npm:7.10.1"]
@@ -2634,24 +3020,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@babel/preset-react", [
-        ["virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1", {
-          "packageLocation": "./.yarn/$$virtual/@babel-preset-react-virtual-d12d050014/4/.yarncache/berry/cache/@babel-preset-react-npm-7.10.1-29f9c88dd2-2.zip/node_modules/@babel/preset-react/",
-          "packageDependencies": [
-            ["@babel/preset-react", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
-            ["@babel/core", "npm:7.8.6"],
-            ["@babel/helper-plugin-utils", "npm:7.10.1"],
-            ["@babel/plugin-transform-react-display-name", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
-            ["@babel/plugin-transform-react-jsx", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
-            ["@babel/plugin-transform-react-jsx-development", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
-            ["@babel/plugin-transform-react-jsx-self", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
-            ["@babel/plugin-transform-react-jsx-source", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
-            ["@babel/plugin-transform-react-pure-annotations", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"]
-          ],
-          "packagePeers": [
-            "@babel/core"
-          ],
-          "linkType": "HARD",
-        }],
         ["virtual:2ceb4517298ac0ac865b67630b09dbd12ce833d767bf3f69c8877bfcc9911d47df368a52689e47616990fc75abebc9a356eb981a9665ae81bc2c7516cedb8735#npm:7.8.3", {
           "packageLocation": "./.yarn/$$virtual/@babel-preset-react-virtual-83a87597df/4/.yarncache/berry/cache/@babel-preset-react-npm-7.8.3-23036eb9b8-2.zip/node_modules/@babel/preset-react/",
           "packageDependencies": [
@@ -2662,6 +3030,24 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/plugin-transform-react-jsx", "virtual:83a87597dffd7e0b474b6dc0c61f3ec64333d5a4fb5935014d99c854e4a9ab2bb7b68c5dbe2ece1899f64de820dfe8d5c264e25904a482b953aad978e5851808#npm:7.8.3"],
             ["@babel/plugin-transform-react-jsx-self", "virtual:83a87597dffd7e0b474b6dc0c61f3ec64333d5a4fb5935014d99c854e4a9ab2bb7b68c5dbe2ece1899f64de820dfe8d5c264e25904a482b953aad978e5851808#npm:7.8.3"],
             ["@babel/plugin-transform-react-jsx-source", "virtual:83a87597dffd7e0b474b6dc0c61f3ec64333d5a4fb5935014d99c854e4a9ab2bb7b68c5dbe2ece1899f64de820dfe8d5c264e25904a482b953aad978e5851808#npm:7.8.3"]
+          ],
+          "packagePeers": [
+            "@babel/core"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1", {
+          "packageLocation": "./.yarn/$$virtual/@babel-preset-react-virtual-efba1491e7/4/.yarncache/berry/cache/@babel-preset-react-npm-7.10.1-29f9c88dd2-2.zip/node_modules/@babel/preset-react/",
+          "packageDependencies": [
+            ["@babel/preset-react", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
+            ["@babel/core", "npm:7.8.6"],
+            ["@babel/helper-plugin-utils", "npm:7.10.1"],
+            ["@babel/plugin-transform-react-display-name", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx-development", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx-self", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-jsx-source", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"],
+            ["@babel/plugin-transform-react-pure-annotations", "virtual:d12d050014d74fd190b726ff771a1c0334e7fe418f664fdf2d3a91dd76a57a9e5efe91921d1369518d65175eea5afcf33a88c45f3ff7771cd0d1ab279b5ca941#npm:7.10.1"]
           ],
           "packagePeers": [
             "@babel/core"
@@ -2731,6 +3117,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-template-npm-7.10.3-8bb92bded3-2.zip/node_modules/@babel/template/",
+          "packageDependencies": [
+            ["@babel/template", "npm:7.10.3"],
+            ["@babel/code-frame", "npm:7.10.3"],
+            ["@babel/parser", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:7.8.6", {
           "packageLocation": "../../../.yarncache/berry/cache/@babel-template-npm-7.8.6-66dd9a450c-2.zip/node_modules/@babel/template/",
           "packageDependencies": [
@@ -2753,6 +3149,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@babel/helper-split-export-declaration", "npm:7.10.1"],
             ["@babel/parser", "npm:7.10.2"],
             ["@babel/types", "npm:7.10.2"],
+            ["debug", "virtual:0a521940d2e91b1c6692c9acbf402a5174688acb05e3c91ae8b352cb29321f3e56574456b4fc5192480b229f8db3b4eb00a711894e67f725e516ce216c9495f1#npm:4.1.1"],
+            ["globals", "npm:11.12.0"],
+            ["lodash", "npm:4.17.15"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-traverse-npm-7.10.3-1706985115-2.zip/node_modules/@babel/traverse/",
+          "packageDependencies": [
+            ["@babel/traverse", "npm:7.10.3"],
+            ["@babel/code-frame", "npm:7.10.3"],
+            ["@babel/generator", "npm:7.10.3"],
+            ["@babel/helper-function-name", "npm:7.10.3"],
+            ["@babel/helper-split-export-declaration", "npm:7.10.1"],
+            ["@babel/parser", "npm:7.10.3"],
+            ["@babel/types", "npm:7.10.3"],
             ["debug", "virtual:0a521940d2e91b1c6692c9acbf402a5174688acb05e3c91ae8b352cb29321f3e56574456b4fc5192480b229f8db3b4eb00a711894e67f725e516ce216c9495f1#npm:4.1.1"],
             ["globals", "npm:11.12.0"],
             ["lodash", "npm:4.17.15"]
@@ -2782,6 +3194,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/types", "npm:7.10.2"],
             ["@babel/helper-validator-identifier", "npm:7.10.1"],
+            ["lodash", "npm:4.17.15"],
+            ["to-fast-properties", "npm:2.0.0"]
+          ],
+          "linkType": "HARD",
+        }],
+        ["npm:7.10.3", {
+          "packageLocation": "../../../.yarncache/berry/cache/@babel-types-npm-7.10.3-0763cc5aa3-2.zip/node_modules/@babel/types/",
+          "packageDependencies": [
+            ["@babel/types", "npm:7.10.3"],
+            ["@babel/helper-validator-identifier", "npm:7.10.3"],
             ["lodash", "npm:4.17.15"],
             ["to-fast-properties", "npm:2.0.0"]
           ],
@@ -4565,14 +4987,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["babel-preset-gatsby-package", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.4"],
             ["@babel/core", "npm:7.8.6"],
-            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
+            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
             ["@babel/plugin-proposal-optional-chaining", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
-            ["@babel/plugin-syntax-dynamic-import", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.8.3"],
+            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
             ["@babel/plugin-transform-runtime", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
             ["@babel/plugin-transform-typescript", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
             ["@babel/preset-env", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.2"],
-            ["@babel/preset-flow", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
-            ["@babel/preset-react", "virtual:0665bdba0c82b69e80abac1e32853c46b8cc0d8c83cc74a3b3d6f7db422eaea1e2ac2a2fc601dc08e0bba9d78089f91641bdff3a132e9585644532f8002dd47e#npm:7.10.1"],
+            ["@babel/preset-flow", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
+            ["@babel/preset-react", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
             ["babel-plugin-dynamic-import-node", "npm:2.3.3"],
             ["core-js", "npm:2.6.11"]
           ],
@@ -8678,6 +9100,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["gatsby-plugin-ts-config", "workspace:."],
             ["@babel/core", "npm:7.8.6"],
+            ["@babel/plugin-proposal-nullish-coalescing-operator", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
+            ["@babel/plugin-proposal-optional-chaining", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/plugin-syntax-dynamic-import", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
+            ["@babel/plugin-transform-runtime", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/plugin-transform-typescript", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/preset-env", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.3"],
+            ["@babel/preset-flow", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
+            ["@babel/preset-react", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.10.1"],
             ["@babel/preset-typescript", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.3"],
             ["@babel/register", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:7.8.6"],
             ["@babel/runtime", "npm:7.8.7"],
@@ -8691,6 +9121,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/parser", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.21.0"],
             ["@typescript-eslint/typescript-estree", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.21.0"],
             ["@yarnpkg/pnpify", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.0.0-rc.18"],
+            ["babel-plugin-dynamic-import-node", "npm:2.3.3"],
             ["babel-preset-gatsby-package", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.4"],
             ["eslint", "npm:6.8.0"],
             ["fs-extra", "npm:8.1.0"],

--- a/.pnp.js
+++ b/.pnp.js
@@ -68,7 +68,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ts-transformer-keys", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.1"],
             ["ttypescript", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:1.5.10"],
             ["type-fest", "npm:0.12.0"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"]
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"]
           ],
           "packagePeers": [
             "@babel/core",
@@ -3533,7 +3533,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["functional-red-black-tree", "npm:1.0.1"],
             ["regexpp", "npm:3.0.0"],
             ["tsutils", "virtual:664e8d9a2b71c44247c1fa5316f79e9741d56b404ee0e224966fc524a7efe664c5af1c0729312697bad1b3655c5f45ca85e880752e3f6d69808734f4bb3bad1d#npm:3.17.1"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"]
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"]
           ],
           "packagePeers": [
             "eslint",
@@ -3600,7 +3600,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/typescript-estree", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.21.0"],
             ["eslint", "npm:6.8.0"],
             ["eslint-visitor-keys", "npm:1.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"]
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"]
           ],
           "packagePeers": [
             "eslint",
@@ -3621,7 +3621,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["lodash", "npm:4.17.15"],
             ["semver", "npm:6.3.0"],
             ["tsutils", "virtual:664e8d9a2b71c44247c1fa5316f79e9741d56b404ee0e224966fc524a7efe664c5af1c0729312697bad1b3655c5f45ca85e880752e3f6d69808734f4bb3bad1d#npm:3.17.1"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"]
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"]
           ],
           "packagePeers": [
             "typescript"
@@ -3902,7 +3902,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["comment-json", "npm:2.4.2"],
             ["cross-spawn", "npm:6.0.5"],
             ["eslint", "npm:6.8.0"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"]
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"]
           ],
           "packagePeers": [
             "eslint",
@@ -8862,7 +8862,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ts-transformer-keys", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.1"],
             ["ttypescript", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:1.5.10"],
             ["type-fest", "npm:0.12.0"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"]
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"]
           ],
           "packagePeers": [
             "@babel/core",
@@ -16544,7 +16544,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["diff", "npm:4.0.2"],
             ["make-error", "npm:1.3.6"],
             ["source-map-support", "npm:0.5.16"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"],
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"],
             ["yn", "npm:3.1.1"]
           ],
           "packagePeers": [
@@ -16571,7 +16571,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/$$virtual/ts-transformer-keys-virtual-fee564c4ab/4/.yarncache/berry/cache/ts-transformer-keys-npm-0.4.1-b004efae13-2.zip/node_modules/ts-transformer-keys/",
           "packageDependencies": [
             ["ts-transformer-keys", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.1"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"]
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"]
           ],
           "packagePeers": [
             "typescript"
@@ -16606,7 +16606,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["tsutils", "virtual:664e8d9a2b71c44247c1fa5316f79e9741d56b404ee0e224966fc524a7efe664c5af1c0729312697bad1b3655c5f45ca85e880752e3f6d69808734f4bb3bad1d#npm:3.17.1"],
             ["tslib", "npm:1.11.1"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"]
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"]
           ],
           "packagePeers": [
             "typescript"
@@ -16630,7 +16630,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ttypescript", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:1.5.10"],
             ["resolve", "patch:resolve@npm%3A1.15.1#builtin<compat/resolve>::version=1.15.1&hash=8fccd0"],
             ["ts-node", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:8.6.2"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"]
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"]
           ],
           "packagePeers": [
             "ts-node",
@@ -16731,10 +16731,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["typescript", [
-        ["patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569", {
-          "packageLocation": "../../../.yarncache/berry/cache/typescript-patch-f2a448b761-2.zip/node_modules/typescript/",
+        ["patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569", {
+          "packageLocation": "../../../.yarncache/berry/cache/typescript-patch-681ec47706-2.zip/node_modules/typescript/",
           "packageDependencies": [
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"]
+            ["typescript", "patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"]
           ],
           "linkType": "HARD",
         }]

--- a/.pnp.js
+++ b/.pnp.js
@@ -54,6 +54,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fs-extra", "npm:8.1.0"],
             ["gatsby", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.19.23"],
             ["lodash.mergewith", "npm:4.6.2"],
+            ["npm-run-all", "npm:4.1.5"],
             ["rimraf", "npm:3.0.2"],
             ["ts-node", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:8.6.2"],
             ["ts-transformer-keys", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.1"],
@@ -8695,6 +8696,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fs-extra", "npm:8.1.0"],
             ["gatsby", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:2.19.23"],
             ["lodash.mergewith", "npm:4.6.2"],
+            ["npm-run-all", "npm:4.1.5"],
             ["rimraf", "npm:3.0.2"],
             ["ts-node", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:8.6.2"],
             ["ts-transformer-keys", "virtual:455ed1d2464b485cc86ccc4ab476e3f5467d6e4b22bcd693bb203b6cd5a170f39c93cb8846df1485e5f45852a3adfd0d5db454abd799e7e78a57a9d40b32555c#npm:0.4.1"],
@@ -11043,6 +11045,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["strip-bom", "npm:3.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:4.0.0", {
+          "packageLocation": "../../../.yarncache/berry/cache/load-json-file-npm-4.0.0-c9f09d85eb-2.zip/node_modules/load-json-file/",
+          "packageDependencies": [
+            ["load-json-file", "npm:4.0.0"],
+            ["graceful-fs", "npm:4.2.3"],
+            ["parse-json", "npm:4.0.0"],
+            ["pify", "npm:3.0.0"],
+            ["strip-bom", "npm:3.0.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["loader-fs-cache", [
@@ -11480,6 +11493,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["memory-fs", "npm:0.5.0"],
             ["errno", "npm:0.1.7"],
             ["readable-stream", "npm:2.3.7"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["memorystream", [
+        ["npm:0.3.1", {
+          "packageLocation": "../../../.yarncache/berry/cache/memorystream-npm-0.3.1-ae973f1d16-2.zip/node_modules/memorystream/",
+          "packageDependencies": [
+            ["memorystream", "npm:0.3.1"]
           ],
           "linkType": "HARD",
         }]
@@ -12216,6 +12238,24 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ignore-walk", "npm:3.0.3"],
             ["npm-bundled", "npm:1.1.1"],
             ["npm-normalize-package-bin", "npm:1.0.1"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["npm-run-all", [
+        ["npm:4.1.5", {
+          "packageLocation": "../../../.yarncache/berry/cache/npm-run-all-npm-4.1.5-3281f1c563-2.zip/node_modules/npm-run-all/",
+          "packageDependencies": [
+            ["npm-run-all", "npm:4.1.5"],
+            ["ansi-styles", "npm:3.2.1"],
+            ["chalk", "npm:2.4.2"],
+            ["cross-spawn", "npm:6.0.5"],
+            ["memorystream", "npm:0.3.1"],
+            ["minimatch", "npm:3.0.4"],
+            ["pidtree", "npm:0.3.1"],
+            ["read-pkg", "npm:3.0.0"],
+            ["shell-quote", "npm:1.7.2"],
+            ["string.prototype.padend", "npm:3.1.0"]
           ],
           "linkType": "HARD",
         }]
@@ -13047,6 +13087,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD",
         }],
+        ["npm:3.0.0", {
+          "packageLocation": "../../../.yarncache/berry/cache/path-type-npm-3.0.0-252361a0eb-2.zip/node_modules/path-type/",
+          "packageDependencies": [
+            ["path-type", "npm:3.0.0"],
+            ["pify", "npm:3.0.0"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:4.0.0", {
           "packageLocation": "../../../.yarncache/berry/cache/path-type-npm-4.0.0-10d47fc86a-2.zip/node_modules/path-type/",
           "packageDependencies": [
@@ -13092,6 +13140,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "../../../.yarncache/berry/cache/picomatch-npm-2.2.1-a4bfb8b1cc-2.zip/node_modules/picomatch/",
           "packageDependencies": [
             ["picomatch", "npm:2.2.1"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["pidtree", [
+        ["npm:0.3.1", {
+          "packageLocation": "../../../.yarncache/berry/cache/pidtree-npm-0.3.1-70dda1cc59-2.zip/node_modules/pidtree/",
+          "packageDependencies": [
+            ["pidtree", "npm:0.3.1"]
           ],
           "linkType": "HARD",
         }]
@@ -14178,6 +14235,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["path-type", "npm:2.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:3.0.0", {
+          "packageLocation": "../../../.yarncache/berry/cache/read-pkg-npm-3.0.0-41471436cb-2.zip/node_modules/read-pkg/",
+          "packageDependencies": [
+            ["read-pkg", "npm:3.0.0"],
+            ["load-json-file", "npm:4.0.0"],
+            ["normalize-package-data", "npm:2.5.0"],
+            ["path-type", "npm:3.0.0"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["read-pkg-up", [
@@ -15136,6 +15203,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jsonify", "npm:0.0.0"]
           ],
           "linkType": "HARD",
+        }],
+        ["npm:1.7.2", {
+          "packageLocation": "../../../.yarncache/berry/cache/shell-quote-npm-1.7.2-8e2768dbb0-2.zip/node_modules/shell-quote/",
+          "packageDependencies": [
+            ["shell-quote", "npm:1.7.2"]
+          ],
+          "linkType": "HARD",
         }]
       ]],
       ["side-channel", [
@@ -15760,6 +15834,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["internal-slot", "npm:1.0.2"],
             ["regexp.prototype.flags", "npm:1.3.0"],
             ["side-channel", "npm:1.0.2"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["string.prototype.padend", [
+        ["npm:3.1.0", {
+          "packageLocation": "../../../.yarncache/berry/cache/string.prototype.padend-npm-3.1.0-8bc3f9cf35-2.zip/node_modules/string.prototype.padend/",
+          "packageDependencies": [
+            ["string.prototype.padend", "npm:3.1.0"],
+            ["define-properties", "npm:1.1.3"],
+            ["es-abstract", "npm:1.17.4"]
           ],
           "linkType": "HARD",
         }]

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ _For the moment, there is no way to layer `ts-node` -> `babel`, but the feature 
 
 ### Extended Usage
 
-If, for some reason, you need to force this plugin to resolve files relative to a different directory than
+If, for some reason, you need to force this plugin to resolve files relative to a directory other than
 your process current working directory, then you can define the `projectRoot` option:
 
 ```js
@@ -131,7 +131,7 @@ module.exports = generateConfig({
 });
 ```
 
-When using this plugin, it is preferable to keep the configuration files out of my project root, because
+When using this plugin, it is preferable to keep the configuration files out of your project root, because
 this helps avoid Gatsby node ownership conflicts.
 
 ```js
@@ -310,12 +310,19 @@ defined below
 * `cacheDir`: `{string}`
   * The cache folder location that the plugin will use to store any of the files that it needs to.
 * `endpoints`: `{object}`
+  * A collection of the fully qualified paths for all of the Gatsby configuration files that have been
+    resolved, and that will be called, by this plugin.  This will be equal to any of the endpoints that
+    you have in your `configDir`, with one exception:
+    * If your `configDir` is the same as the `projectRoot`, then `gatsby-ssr` and `gastby-browser` will
+      **not** be included in these resolved endpoints, because they will not be called by this plugin.
   * Properties:
     * config: `{string[]}` - The list of chained requires/imports that were performed by `gatsby-config`
     * node: `{string[]}` - The list of chained requires/imports that were performed by `gatsby-node`
     * browser: `{string[]}` - The resolved path of the `gatsby-browser` api endpoint
     * ssr: `{string[]}` - The resolved path of the `gatsby-ssr` api endpoint
-    * plugin:
+    * plugin - Contains the collection of all the plugins that have been resolved by the `includePlugins()` function,
+      defined below.  `name` will be the registered name of the plugin, and the `config`, `node`, `browser`,
+      and `ssr` properties will be the same as defined above.
       * Type:
 
       ```js
@@ -329,36 +336,30 @@ defined below
       }
       ```
 
-      * Contains the collection of all the plugins that have been resolved by the `includePlugins()` function,
-        defined below.  `name` will be the registered name of the plugin, and the `config`, `node`, `browser`,
-        and `ssr` properties will be the same as defined above.
-
-  * A collection of the fully qualified paths for all of the Gatsby configuration files that have been
-    resolved, and that will be called, by this plugin.  This will be equal to any of the endpoints that
-    you have in your `configDir`, with one exception:
-    * If your `configDir` is the same as the `projectRoot`, then `gatsby-ssr` and `gastby-browser` will
-      **not** be included in these resolved endpoints, because they will not be called by this plugin.
   * If the `browser` or `ssr` properties are included, they will only have one index, containing the
     location of the endpoint that was resolved.  This is because transpiling & compiling of those modules
     is done by Gatsby itself, not this module.
-  * The first index of each property will always be the Gatsby endpoint.  All following indexes will be
+  * The first index of each property will always be your local Gatsby endpoint.  All following indexes will be
     the files that were required/imported by that one
+
+
 
 #### `gatsby-config` utilites
 
 1. `includePlugins`: This function allows you to register plugins with strongly typed options.  Using it
   also enables advanced plugin resolution, allowing you to automatically resolve local plugins.  Any
-  plugins resolved this way will also be compiled, so if you have plugins written in Typescript, they
+  plugins resolved this way will also be compiled, so if you have local plugins written in Typescript, they
   will be transpiled so that they can be consumed by Gatsby.
 
     * There are few overloads for this function.
 
       1. You may include an array of plugins in the first parameter, which takes the same shape as Gatsby's
-        plugin array.
-      2. You may optionally include a callback function in the second parameter.  It will receive all of the
-        same parameters defined above for the `gatsby-*` as-a-function.  It must return an array in the same
-        shape as Gatsby's plugin array.
-      3. Or, you may include only the callback function in the first parameter.
+         plugin array.
+          * You may optionally include a **callback function** in the second parameter.  It will receive all of the
+            same parameters defined above for the `gatsby-*` as-a-function.  It must return an array in the same
+            shape as Gatsby's plugin array.
+
+      2. Or, you may include only the **callback function** in the first parameter.
 
     * Any plugins defined in the array in the first parameter will be resolved before the normal Gatsby plugin
       array is processed.  This means that any plugins resolved this way will be available to the normal
@@ -380,7 +381,7 @@ A couple of utility interfaces are exported by this plugin to make it easier to 
 type-safe functions in `gatsby-node` and `gatsby-config`:
 
 * `ITSConfigFn`: Interface that describes the shape of the `gatsby-config` or `gatsby-node`
-  default function exports.  Accepts one parameters:
+  default function exports.  Accepts one parameter:
   * The string parameter for the function type ('config' | 'node')
 
 * `IGatsbyPluginDef`: Utility type that makes it easy to merge a plugin's defined types

--- a/README.md
+++ b/README.md
@@ -118,44 +118,10 @@ this plugin, and the rest of your configuration will be in Typescript files.
 _For the moment, there is no way to layer `ts-node` -> `babel`, but the feature may be included
    in a later release_
 
-For example:
-
-```js
-// Picks babel
-const { generateConfig } = require('gatsby-plugin-ts-config');
-module.exports = generateConfig();
-
-// Picks babel
-const { generateConfig } = require('gatsby-plugin-ts-config');
-module.exports = generateConfig({
-  babel: true,
-});
-
-// Picks babel
-const { generateConfig } = require('gatsby-plugin-ts-config');
-module.exports = generateConfig({
-  babel: true,
-  tsNode: true,
-});
-
-// Picks ts-node
-const { generateConfig } = require('gatsby-plugin-ts-config');
-module.exports = generateConfig({
-  tsNode: true,
-});
-
-// Picks ts-node
-const { generateConfig } = require('gatsby-plugin-ts-config');
-module.exports = generateConfig({
-  babel: false,
-  tsNode: true,
-});
-```
-
 ### Extended Usage
 
 If, for some reason, you need to force this plugin to resolve files relative to a different directory than
-your process' current working directory, then you can define the `projectRoot` option:
+your process current working directory, then you can define the `projectRoot` option:
 
 ```js
 // gatsby-config.js
@@ -349,6 +315,24 @@ defined below
     * node: `{string[]}` - The list of chained requires/imports that were performed by `gatsby-node`
     * browser: `{string[]}` - The resolved path of the `gatsby-browser` api endpoint
     * ssr: `{string[]}` - The resolved path of the `gatsby-ssr` api endpoint
+    * plugin:
+      * Type:
+
+      ```js
+      {
+        [name: string]: {
+          config: string[];
+          node: string[];
+          browser: string[];
+          ssr: string[];
+        }
+      }
+      ```
+
+      * Contains the collection of all the plugins that have been resolved by the `includePlugins()` function,
+        defined below.  `name` will be the registered name of the plugin, and the `config`, `node`, `browser`,
+        and `ssr` properties will be the same as defined above.
+
   * A collection of the fully qualified paths for all of the Gatsby configuration files that have been
     resolved, and that will be called, by this plugin.  This will be equal to any of the endpoints that
     you have in your `configDir`, with one exception:
@@ -360,18 +344,46 @@ defined below
   * The first index of each property will always be the Gatsby endpoint.  All following indexes will be
     the files that were required/imported by that one
 
+#### `gatsby-config` utilites
+
+1. `includePlugins`: This function allows you to register plugins with strongly typed options.  Using it
+  also enables advanced plugin resolution, allowing you to automatically resolve local plugins.  Any
+  plugins resolved this way will also be compiled, so if you have plugins written in Typescript, they
+  will be transpiled so that they can be consumed by Gatsby.
+
+    * There are few overloads for this function.
+
+      1. You may include an array of plugins in the first parameter, which takes the same shape as Gatsby's
+        plugin array.
+      2. You may optionally include a callback function in the second parameter.  It will receive all of the
+        same parameters defined above for the `gatsby-*` as-a-function.  It must return an array in the same
+        shape as Gatsby's plugin array.
+      3. Or, you may include only the callback function in the first parameter.
+
+    * Any plugins defined in the array in the first parameter will be resolved before the normal Gatsby plugin
+      array is processed.  This means that any plugins resolved this way will be available to the normal
+      function export.
+
+    * Any callback functions defined this way will be called, in sequence, after the normal Gatsby array has
+      been processed.  This means that all of the plugins from the previously defined array(s), and the normal
+      Gatsby array will be available in the callback's parameters.
+
+    * The ordering of the plugins will be the same as the order they are resolved.
+
+      1. Arrays resolved by this function
+      2. Standard Gatsby array
+      3. Callback function arrays
+
 #### Type utilities
 
 A couple of utility interfaces are exported by this plugin to make it easier to create
 type-safe functions in `gatsby-node` and `gatsby-config`:
 
 * `ITSConfigFn`: Interface that describes the shape of the `gatsby-config` or `gatsby-node`
-  default function exports.  Accepts two parameters:
+  default function exports.  Accepts one parameters:
   * The string parameter for the function type ('config' | 'node')
-  * In the case of 'config', a union of plugin option interfaces, to allow you to design a
-    strongly typed object export.
 
-* `IMergePluginOptions`: Utility type that makes it easy to merge a plugin's defined types
+* `IGatsbyPluginDef`: Utility type that makes it easy to merge a plugin's defined types
   into your plugins object array.  Accepts two parameters:
   * The name of the plugin, which will be used in the `resolve` property
   * The interface for the plugin's options
@@ -383,14 +395,53 @@ type-safe functions in `gatsby-node` and `gatsby-config`:
   _One good example is the plugin [`gatsby-plugin-pnpm`](https://github.com/Js-Brecht/gatsby-plugin-pnpm),
   since it exports the interface for the options that are valid for it.  They could be used like this:_
 
-  ```ts
-  import { IPluginOptions as IPnpmPluginOptions } from 'gatsby-plugin-pnpm';
-  import { ITSConfigFn, IMergePluginOptions } from 'gatsby-plugin-ts-config';
+  _Another example would be [`gatsby-source-filesystem`](https://github.com/gatsbyjs/gatsby/blob/c1368c06fb975bd792ebb8f9d0c5a5e4ebcba388/packages/gatsby-source-filesystem/index.d.ts#L100-L103).  As you'll notice, its interface is already
+  configured to use the `resolve` and `options` properties, so the `IGatsbyPluginDef` wouldn't be needed._
 
-  const gatsbyConfig: ITSConfigFn<'config',
-    | IMergePluginOptions<'gatsby-plugin-pnpm', IPnpmPluginOptions>
-    | /* Add more merged types here */
-  > = ({
+  ```ts
+  import type { IPluginOptions as IPnpmPluginOptions } from 'gatsby-plugin-pnpm';
+  import type { FileSystemConfig } from 'gatsby-plugin-filesystem';
+  import { ITSConfigFn, IGatsbyPluginDef, includePlugins } from 'gatsby-plugin-ts-config';
+
+  includePlugins<
+    | IGatsbyPluginDef<'gatsby-plugin-pnpm', IPnpmPluginOptions>
+    | FileSystemConfig
+  >([
+    {
+      resolve: 'gatsby-plugin-pnpm', // <-- this will be typed
+      options: {
+        ... // <-- These will be typed
+      }
+    }
+  ], ({
+    projectRoot,
+  }) => ([
+    {
+      resolve: 'gatsby-source-filesystem' // <-- this will be typed
+      options: {
+        ... // <-- These will be typed
+      }
+    }
+  ]))
+
+  // If you want to define a plugin that will receive the previous callback's
+  // resolved plugins (gatsby-source-filesystem), then you can call the function
+  // again
+
+  includePlugins<
+    | IGatsbyPluginDef<'foo-plugin-that-receives-filesystem-endpoints', IFooPluginOptions>
+  >(({
+    endpoints,
+  }) => ([
+    {
+      resolve: 'foo-plugin-....',
+      options: {
+        pluginPaths: endpoints.plugin['gatsby-source-filesystem'].node,
+      }
+    }
+  ]))
+
+  const gatsbyConfig: ITSConfigFn<'config'> = ({
     projectRoot
   }) => ({
     siteMetadata: {
@@ -400,10 +451,7 @@ type-safe functions in `gatsby-node` and `gatsby-config`:
     },
     plugins: [
       {
-        resolve: `gatsby-plugin-pnpm`, // <-- This will have intellisense
-        options: { // <-- These will have intellisense, and will be type-checked
-          projectPath: projectRoot
-        }
+        // All of your normal, untyped Gatsby plugins
       }
     ]
   });

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ type-safe functions in `gatsby-node` and `gatsby-config`:
   since it exports the interface for the options that are valid for it.  They could be used like this:_
 
   _Another example would be [`gatsby-source-filesystem`](https://github.com/gatsbyjs/gatsby/blob/c1368c06fb975bd792ebb8f9d0c5a5e4ebcba388/packages/gatsby-source-filesystem/index.d.ts#L100-L103).  As you'll notice, its interface is already
-  configured to use the `resolve` and `options` properties, so the `IGatsbyPluginDef` wouldn't be needed._
+  configured to use the `resolve` and `options` properties, so `IGatsbyPluginDef` wouldn't be needed._
 
   ```ts
   import type { IPluginOptions as IPnpmPluginOptions } from 'gatsby-plugin-pnpm';

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,3 +1,3 @@
 "use strict";
 
-module.exports = require("ts-config-cache-dir/gatsby-browser");
+module.exports = require("gatsby-plugin-ts-config-cache/gatsby-browser");

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,4 +4,4 @@ exports.onPreRenderHTML = function () {
     return null;
 };
 
-module.exports = require("ts-config-cache-dir/gatsby-ssr");
+module.exports = require("gatsby-plugin-ts-config-cache/gatsby-ssr");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gatsby-plugin-ts-config",
-	"version": "1.0.0-rc.2",
+	"version": "1.0.0-rc.3",
 	"description": "Configure Gatsby to use Typescript configuration files",
 	"main": "./index.js",
 	"types": "./dist/index",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,12 @@
 	],
 	"scripts": {
 		"purge": "rimraf node_modules && yarn clean",
-		"clean": "rimraf ./dist",
-		"prebuild": "npm run clean",
-		"build": "ttsc",
-		"build:map": "ttsc --sourceMap",
-		"watch": "npm run build -- -w",
+		"clean": "rimraf ./dist/*",
+    "build": "run-s clean build:prod",
+    "build:prod": "ttsc",
+		"build:dev": "run-s \"build:prod --sourceMap\"",
+		"watch": "run-s clean \"build:prod -w\"",
+		"watch:dev": "run-s clean \"build:dev -w\"",
 		"lint": "eslint -c .eslintrc ./src/**/*"
 	},
 	"peerDependencies": {
@@ -79,6 +80,7 @@
 		"@yarnpkg/pnpify": "^2.0.0-rc.18",
 		"eslint": "^6.8.0",
 		"gatsby": "^2.19.18",
+		"npm-run-all": "^4.1.5",
 		"rimraf": "^3.0.2",
 		"ts-transformer-keys": "^0.4.1",
 		"ttypescript": "^1.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gatsby-plugin-ts-config",
-	"version": "1.0.0-rc.1",
+	"version": "1.0.0-rc.2",
 	"description": "Configure Gatsby to use Typescript configuration files",
 	"main": "./index.js",
 	"types": "./dist/index",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"clean": "rimraf ./dist/*",
 		"build": "run-s clean build:prod",
 		"build:prod": "ttsc",
-		"build:dev": "run-s \"build:prod --sourceMap\"",
+		"build:dev": "ttsc --sourceMap",
 		"watch": "run-s clean \"build:prod -w\"",
 		"watch:dev": "run-s clean \"build:dev -w\"",
 		"lint": "eslint -c .eslintrc ./src/**/*",
@@ -94,7 +94,7 @@
 		"ts-transformer-keys": "^0.4.1",
 		"ttypescript": "^1.5.10",
 		"type-fest": "^0.12.0",
-		"typescript": "3.8.3"
+		"typescript": "3.9.6"
 	},
 	"dependenciesMeta": {
 		"@jtechsvcs/eslint-config-typescript": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"prepublishOnly": "yarn build"
 	},
 	"peerDependencies": {
-		"@babel/core": "^7.0.0",
+		"@babel/core": "^7.9.0",
 		"@babel/runtime": "^7.8.7",
 		"gatsby": "~2.x.x",
 		"typescript": "~3.x.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gatsby-plugin-ts-config",
-	"version": "1.0.0-rc.3",
+	"version": "1.0.0-rc.4",
 	"description": "Configure Gatsby to use Typescript configuration files",
 	"main": "./index.js",
 	"types": "./dist/index",

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
 	"scripts": {
 		"purge": "rimraf node_modules && yarn clean",
 		"clean": "rimraf ./dist/*",
-    "build": "run-s clean build:prod",
-    "build:prod": "ttsc",
+		"build": "run-s clean build:prod",
+		"build:prod": "ttsc",
 		"build:dev": "run-s \"build:prod --sourceMap\"",
 		"watch": "run-s clean \"build:prod -w\"",
 		"watch:dev": "run-s clean \"build:dev -w\"",
-    "lint": "eslint -c .eslintrc ./src/**/*",
-    "prepublish": "yarn build"
+		"lint": "eslint -c .eslintrc ./src/**/*",
+		"prepublish": "yarn build"
 	},
 	"peerDependencies": {
 		"@babel/core": "^7.0.0",
@@ -59,9 +59,18 @@
 		}
 	},
 	"dependencies": {
+		"@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
+		"@babel/plugin-proposal-optional-chaining": "^7.10.3",
+		"@babel/plugin-syntax-dynamic-import": "^7.8.3",
+		"@babel/plugin-transform-runtime": "^7.10.3",
+		"@babel/plugin-transform-typescript": "^7.10.3",
+		"@babel/preset-env": "^7.10.3",
+		"@babel/preset-flow": "^7.10.1",
+		"@babel/preset-react": "^7.10.1",
 		"@babel/preset-typescript": "^7.8.3",
 		"@babel/register": "^7.8.6",
 		"@babel/runtime": "^7.8.7",
+		"babel-plugin-dynamic-import-node": "^2.3.3",
 		"babel-preset-gatsby-package": "^0.4.4",
 		"fs-extra": "^8.1.0",
 		"lodash.mergewith": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
 		"@babel/register": "^7.8.6",
 		"@babel/runtime": "^7.8.7",
 		"babel-plugin-dynamic-import-node": "^2.3.3",
-		"babel-preset-gatsby-package": "^0.4.4",
 		"fs-extra": "^8.1.0",
 		"lodash.mergewith": "^4.6.2",
 		"ts-node": "^8.6.2"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"watch": "run-s clean \"build:prod -w\"",
 		"watch:dev": "run-s clean \"build:dev -w\"",
 		"lint": "eslint -c .eslintrc ./src/**/*",
-		"prepublish": "yarn build"
+		"prepublishOnly": "yarn build"
 	},
 	"peerDependencies": {
 		"@babel/core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gatsby-plugin-ts-config",
-	"version": "0.2.3",
+	"version": "1.0.0-rc.1",
 	"description": "Configure Gatsby to use Typescript configuration files",
 	"main": "./index.js",
 	"types": "./dist/index",
@@ -41,7 +41,8 @@
 		"build:dev": "run-s \"build:prod --sourceMap\"",
 		"watch": "run-s clean \"build:prod -w\"",
 		"watch:dev": "run-s clean \"build:dev -w\"",
-		"lint": "eslint -c .eslintrc ./src/**/*"
+    "lint": "eslint -c .eslintrc ./src/**/*",
+    "prepublish": "yarn build"
 	},
 	"peerDependencies": {
 		"@babel/core": "^7.0.0",

--- a/src/gatsby/gatsby-config.ts
+++ b/src/gatsby/gatsby-config.ts
@@ -15,15 +15,6 @@ import OptionsHandler from '../utils/options-handler';
 import type { GatsbyConfig } from 'gatsby';
 import type { ITSConfigArgs, IGatsbyConfigTypes, IEndpointResolutionSpec } from '../types';
 
-import BuiltinModule from 'module';
-
-interface IModule extends BuiltinModule {
-    _extensions: NodeJS.RequireExtensions;
-}
-
-const Module = BuiltinModule as unknown as IModule;
-
-
 export default (args = {} as ITSConfigArgs): GatsbyConfig => {
     const projectRoot = getAbsoluteRelativeTo(args.projectRoot || process.cwd());
     const configDir = getAbsoluteRelativeTo(projectRoot, args.configDir);

--- a/src/gatsby/gatsby-config.ts
+++ b/src/gatsby/gatsby-config.ts
@@ -1,44 +1,44 @@
 import * as path from 'path';
 import { RegisterOptions } from 'ts-node';
 import { TransformOptions } from '@babel/core';
-import { ITSConfigArgs, IConfigTypes, IEndpointResolutionSpec } from '../types';
 import { getAbsoluteRelativeTo } from '../utils/fs-tools';
-import { resolveGatsbyEndpoints, browserSsr } from '../utils/endpoints';
+import {
+    resolveGatsbyEndpoints,
+    allGatsbyEndpoints,
+    ignoreRootEndpoints,
+    configEndpointSpecs,
+    gatsbyConfigEndpoints,
+    compilePlugins,
+} from '../utils/endpoints';
 import { tryRequireModule, getModuleObject } from '../utils/node';
 import RequireRegistrar from '../utils/register';
 import OptionsHandler from '../utils/options-handler';
 
-const gatsbyEndpoints: IConfigTypes[] = [
-    ...browserSsr,
-    'config',
-    'node',
-];
-const ignoreRootConfigs: IConfigTypes[] = [
-    ...browserSsr,
-];
+import type { GatsbyConfig } from 'gatsby';
+import type { ITSConfigArgs, IGatsbyConfigTypes, IEndpointResolutionSpec } from '../types';
 
-export default (args = {} as ITSConfigArgs) => {
+export default (args = {} as ITSConfigArgs): GatsbyConfig => {
     const projectRoot = getAbsoluteRelativeTo(args.projectRoot || process.cwd());
     const configDir = getAbsoluteRelativeTo(projectRoot, args.configDir);
     const cacheDir = path.join(projectRoot, '.cache', 'caches', 'gatsby-plugin-ts-config');
     const pluginDir = path.resolve(path.join(__dirname, '..', '..'));
 
-    const ignore: IConfigTypes[] = [];
+    const ignore: IGatsbyConfigTypes[] = [];
     const configEndpoint: IEndpointResolutionSpec = {
         type: 'config',
         ext: ['.js', '.ts'],
     };
     if (configDir === projectRoot) {
-        ignore.push(...ignoreRootConfigs.filter((nm) => !ignore.includes(nm)));
+        ignore.push(...ignoreRootEndpoints.filter((nm) => !ignore.includes(nm)));
         configEndpoint.ext = ['.ts'];
     }
 
     const endpoints = resolveGatsbyEndpoints({
         endpointSpecs: [
-            ...gatsbyEndpoints.filter((nm) => !ignore.includes(nm) && nm !== 'config'),
+            ...allGatsbyEndpoints.filter((nm) => !ignore.includes(nm) && nm !== 'config'),
             ...(!ignore.includes('config') && [configEndpoint] || []),
         ],
-        configDir,
+        endpointRoot: configDir,
     });
 
     const programOpts = {
@@ -82,9 +82,24 @@ export default (args = {} as ITSConfigArgs) => {
     // retrieved later when it is required in gatsby-node
     const gatsbyNodeModule = tryRequireModule('node', endpoints);
 
+    compilePlugins({
+        plugins: OptionsHandler.plugins,
+    });
+
     const gatsbyConfigModule = tryRequireModule('config', endpoints);
     const gatsbyConfig = getModuleObject(gatsbyConfigModule);
 
+    OptionsHandler.includePlugins(gatsbyConfig?.plugins || []);
+    OptionsHandler.doExtendPlugins(true);
+
     RequireRegistrar.revert();
-    return gatsbyConfig;
+    return {
+        ...gatsbyConfig,
+        plugins: [
+            ...OptionsHandler.plugins.map((plugin) => ({
+                resolve: plugin.path,
+                options: plugin.options,
+            })),
+        ],
+    };
 };

--- a/src/gatsby/gatsby-node.ts
+++ b/src/gatsby/gatsby-node.ts
@@ -3,7 +3,7 @@ import {
     tryRequireModule,
     getModuleObject,
 } from '../utils/node';
-import { setupGatsbyEndpoints } from '../utils/endpoints';
+import { setupGatsbyEndpointProxies } from '../utils/endpoints';
 import OptionsHandler from '../utils/options-handler';
 
 const { endpoints, cacheDir } = OptionsHandler.get();
@@ -44,11 +44,11 @@ export = {
         actions: {
             setWebpackConfig,
         },
-    }: CreateWebpackConfigArgs) => {
+    }) => {
         setWebpackConfig({
             resolve: {
                 alias: {
-                    "ts-config-cache-dir": cacheDir,
+                    "gatsby-plugin-ts-config-cache": cacheDir,
                 },
             },
         });
@@ -56,7 +56,7 @@ export = {
     }),
 
     onPreBootstrap: wrapGatsbyNode('onPreBootstrap', () => {
-        setupGatsbyEndpoints({
+        setupGatsbyEndpointProxies({
             resolvedEndpoints: endpoints,
             distDir: __dirname,
             cacheDir,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,24 @@
-import { ITSConfigArgs, IGatsbyConfig } from './types';
+import OptionsHandler from './utils/options-handler';
 
-type IGeneratedGatsbyConfig = Pick<IGatsbyConfig, 'plugins'>;
+import type { GatsbyConfig } from 'gatsby';
+import type { ITSConfigArgs } from './types';
+
+type IGeneratedGatsbyConfig = Pick<GatsbyConfig, 'plugins'>;
 interface IGenerateConfig {
     (args: ITSConfigArgs): IGeneratedGatsbyConfig;
 }
 
-const generateConfig: IGenerateConfig = (options) => {
+export const generateConfig: IGenerateConfig = (options) => {
     return {
         plugins: [
             {
                 resolve: `gatsby-plugin-ts-config`,
-                options,
+                options: (options as Record<string, any>),
             },
         ],
     };
 };
 
-export {
-    generateConfig,
-};
+export const includePlugins = OptionsHandler.includePlugins;
 
 export * from './types/public';

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -63,7 +63,7 @@ export interface IGatsbyPluginWithOpts<
     TOptions extends Record<string, any> = Record<string, any>
 > {
     resolve: TName;
-    options: TOptions;
+    options?: TOptions;
 }
 
 export interface IPluginDetails {

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -1,7 +1,7 @@
 import { GatsbyConfig, GatsbyNode } from 'gatsby';
 import { RegisterOptions as TSNodeRegisterOptions } from 'ts-node';
 import { TransformOptions } from '@babel/core';
-import { IGlobalOpts } from './internal';
+import { IGlobalOpts, PickLiteral, IGatsbyConfigTypes, IGatsbyPluginWithOpts } from './internal';
 
 interface ITSConfigArgsBase {
     configDir?: string;
@@ -18,11 +18,16 @@ interface ITSConfigArgsJIT extends ITSConfigArgsBase {
 // }
 export interface ITSConfigArgs extends ITSConfigArgsJIT /* | ITSConfigArgsAOT */ {}
 
-export type IPublicOpts = Omit<IGlobalOpts, 'transformOpts' | 'pluginDir'>
+export type IPublicOpts = Omit<IGlobalOpts,
+    | 'transformOpts'
+    | 'pluginDir'
+    | 'babelOpts'
+    | 'tsNodeOpts'
+>
 
-type ITSConfigFnTypes = 'config' | 'node';
-type ITSConfigFnReturn<T extends ITSConfigFnTypes, TMergeConfigs extends IMergePluginOptions = any> = T extends 'config'
-    ? IGatsbyConfig<TMergeConfigs>
+type ITSConfigFnTypes = PickLiteral<IGatsbyConfigTypes, 'config' | 'node'>;
+type ITSConfigFnReturn<T extends ITSConfigFnTypes> = T extends 'config'
+    ? GatsbyConfig
     : GatsbyNode;
 
 /**
@@ -41,7 +46,7 @@ type ITSConfigFnReturn<T extends ITSConfigFnTypes, TMergeConfigs extends IMergeP
  *
  * @example
  * ```ts
- * const gatsbyConfig: ITSConfigFn<'config', FooPluginOptions> = () => ({
+ * const gatsbyConfig: ITSConfigFn<'config'> = () => ({
  *      plugins: [
  *          ...
  *      ]
@@ -49,46 +54,57 @@ type ITSConfigFnReturn<T extends ITSConfigFnTypes, TMergeConfigs extends IMergeP
  * export default gatsbyConfig;
  * ```
  */
-export interface ITSConfigFn<TConfigType extends ITSConfigFnTypes, TMergeConfigs extends IMergePluginOptions = any> {
-    (args: IPublicOpts): ITSConfigFnReturn<TConfigType, TMergeConfigs>;
+export interface ITSConfigFn<TConfigType extends ITSConfigFnTypes> {
+    (args: IPublicOpts): ITSConfigFnReturn<TConfigType>;
 }
 
 /**
- * For plugins that have types defined for their options,
- * but don't include the requisite GatsbyConfig structure (i.e. includes
- * both the `resolve` & `options` properties), you can define them using
- * this interface, and include them in the `ITSConfigFn` type definition
- * as a union in the second parameter
+ * This interface can be used with the `resolvePlugins` utility function
+ * to ensure that the options provided for any defined plugins are
+ * strongly typed.
+ *
+ * @param {string} TName - a string literal that represents the plugin name
+ * @param {object} TOptions - (optional) the possible options for the defined
+ * plugin
  *
  * @example
  * ```ts
- * const gatsbyConfig: ITSConfigFn<'config',
- *      IMergePluginOptions<'gatsby-plugin-foo', FooPluginOptions>
- * > = () => ({
- *      plugins: [
- *          ...
- *      ]
- * })
+ *  interface IBarPluginOptions {
+ *      barOption: 'qux';
+ *  }
+ *
+ *  resolvePlugins<
+ *      | IGatsbyPluginDef<'fooPlugin'>
+ *      | IGatsbyPluginDef<'barPlugin', IBarPluginOptions>
+ *  >([
+ *      // These strings will be strongly typed
+ *      'fooPlugin',
+ *
+ *      // This object will be strongly typed
+ *      {
+ *          resolve: 'barPlugin',
+ *          options: {
+ *              barOption: 'qux',
+ *          }
+ *      }
+ *  ])
  * ```
+ *
+ * @remarks
+ * If a plugin provides its own options interface in the form of
+ *
+ * ```ts
+ *  interface IFooPluginOptions {
+ *      resolve: 'fooPlugin';
+ *      options: {
+ *          fooOption: 'bar';
+ *      }
+ *  }
+ * ```
+ *
+ * It may be used in the place of an `IGatsbyPluginDef` definition
  */
-export type IMergePluginOptions<
-    TName extends string = string,
-    TOptions extends object = {},
-> = {
-    resolve: TName;
-    options: TOptions;
-}
-
-type DefaultPluginDef = IMergePluginOptions<string, Record<string, unknown>>;
-
-/**
- * This interface is used to extend the default GatsbyConfig interface
- * with the additional plugin definitions
- */
-export interface IGatsbyConfig<TPluginDefinition extends IMergePluginOptions = IMergePluginOptions> extends GatsbyConfig {
-    plugins?: Array<
-        | string
-        | DefaultPluginDef
-        | TPluginDefinition
-    >;
-}
+export type IGatsbyPluginDef<TName extends string = string, TOptions extends Record<string, any> = Record<string, any>> = (
+    | TName
+    | IGatsbyPluginWithOpts<TName, TOptions>
+)

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -59,7 +59,7 @@ export interface ITSConfigFn<TConfigType extends ITSConfigFnTypes> {
 }
 
 /**
- * This interface can be used with the `resolvePlugins` utility function
+ * This interface can be used with the `includePlugins` utility function
  * to ensure that the options provided for any defined plugins are
  * strongly typed.
  *
@@ -73,7 +73,7 @@ export interface ITSConfigFn<TConfigType extends ITSConfigFnTypes> {
  *      barOption: 'qux';
  *  }
  *
- *  resolvePlugins<
+ *  includePlugins<
  *      | IGatsbyPluginDef<'fooPlugin'>
  *      | IGatsbyPluginDef<'barPlugin', IBarPluginOptions>
  *  >([

--- a/src/utils/babel.ts
+++ b/src/utils/babel.ts
@@ -2,9 +2,6 @@ import * as path from 'path';
 import {
     ConfigItem,
     CreateConfigItemOptions,
-    ConfigAPI,
-    TransformOptions,
-    PluginItem,
     createConfigItem,
 } from '@babel/core';
 
@@ -45,30 +42,30 @@ export const createPresets: (
     return configItems;
 };
 
-type PresetFn = (context: ConfigAPI, options: object) => TransformOptions;
-type IAddOptsToPresetPlugin = (preset: PresetFn, pluginName: string, opts: object) => PresetFn;
-export const addOptsToPreset: IAddOptsToPresetPlugin = (preset, name, opts) => {
-    const checkItemPath = (item: PluginItem): boolean => {
-        if (!(typeof item === 'string')) return false;
-        const checkPath = name.replace(/^[/\\]+|[/\\]+$/g, '');
-        const pattern = new RegExp(`[/]${checkPath.replace(/[/]/g, '\\/')}[/]`, 'i');
-        return pattern.test(item.replace(/\\/g, '/'));
-    };
+// type PresetFn = (context: ConfigAPI, options: object) => TransformOptions;
+// type IAddOptsToPresetPlugin = (preset: PresetFn, pluginName: string, opts: object) => PresetFn;
+// export const addOptsToPreset: IAddOptsToPresetPlugin = (preset, name, opts) => {
+//     const checkItemPath = (item: PluginItem): boolean => {
+//         if (!(typeof item === 'string')) return false;
+//         const checkPath = name.replace(/^[/\\]+|[/\\]+$/g, '');
+//         const pattern = new RegExp(`[/]${checkPath.replace(/[/]/g, '\\/')}[/]`, 'i');
+//         return pattern.test(item.replace(/\\/g, '/'));
+//     };
 
-    return (context, options = {}) => {
-        const presetResult = preset(context, options);
-        for (const collection of [presetResult.plugins, presetResult.presets]) {
-            if (collection) {
-                collection.forEach((item, idx) => {
-                    if (checkItemPath(item)) {
-                        collection![idx] = [
-                            item,
-                            opts,
-                        ];
-                    }
-                });
-            }
-        }
-        return presetResult;
-    };
-};
+//     return (context, options = {}) => {
+//         const presetResult = preset(context, options);
+//         for (const collection of [presetResult.plugins, presetResult.presets]) {
+//             if (collection) {
+//                 collection.forEach((item, idx) => {
+//                     if (checkItemPath(item)) {
+//                         collection![idx] = [
+//                             item,
+//                             opts,
+//                         ];
+//                     }
+//                 });
+//             }
+//         }
+//         return presetResult;
+//     };
+// };

--- a/src/utils/endpoints.ts
+++ b/src/utils/endpoints.ts
@@ -90,7 +90,7 @@ export interface IMakeGatsbyEndpointProps {
  * * `distDir`: The location of files that can be copied to this user's cache
  * * `cacheDir`: The location to write the proxy module
  */
-export const setupGatsbyEndpoints = ({
+export const setupGatsbyEndpointProxies = ({
     resolvedEndpoints,
     cacheDir,
 }: IMakeGatsbyEndpointProps): void => {

--- a/src/utils/endpoints.ts
+++ b/src/utils/endpoints.ts
@@ -126,7 +126,7 @@ export const resolvePluginPath = ({
     projectRoot,
     pluginName,
 }: IResolvePluginPathProps): string => {
-    const scopedRequire = createRequire(projectRoot);
+    const scopedRequire = createRequire(`${projectRoot}/<internal>`);
     try {
         const pluginPath = path.dirname(
             scopedRequire.resolve(`${pluginName}/package.json`),

--- a/src/utils/endpoints.ts
+++ b/src/utils/endpoints.ts
@@ -1,17 +1,42 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import {
+import { checkFileWithExts, allExt, fileExists, isDir } from './fs-tools';
+import { createRequire, tryRequireModule } from './node';
+
+import type {
     IGatsbyEndpoints,
-    IConfigTypes,
+    IGatsbyConfigTypes,
     IEndpointResolutionSpec,
+    IPluginDetails,
 } from '../types';
-import { checkFileWithExts, allExt } from './fs-tools';
+
+export const gatsbyEndpointProxies: IGatsbyConfigTypes[] = ['browser', 'ssr'];
+export const gatsbyConfigEndpoints: IGatsbyConfigTypes[] = ['config', 'node'];
+export const allGatsbyEndpoints: IGatsbyConfigTypes[] = [
+    ...gatsbyConfigEndpoints,
+    ...gatsbyEndpointProxies,
+];
+export const ignoreRootEndpoints: IGatsbyConfigTypes[] = [
+    ...gatsbyEndpointProxies,
+];
+
+
+export const configEndpointSpecs: IEndpointResolutionSpec[] = [
+    {
+        type: 'config',
+        ext: ['.js', '.ts'],
+    },
+    {
+        type: 'node',
+        ext: ['.js', '.ts'],
+    },
+];
 
 // *************************************
 
 export interface IResolveEndpointProps {
     endpointSpecs: IEndpointResolutionSpec[];
-    configDir: string;
+    endpointRoot: string;
 }
 
 /**
@@ -26,7 +51,7 @@ export interface IResolveEndpointProps {
  */
 export const resolveGatsbyEndpoints = ({
     endpointSpecs,
-    configDir,
+    endpointRoot,
 }: IResolveEndpointProps): IGatsbyEndpoints => {
     const resolved: IGatsbyEndpoints = {};
 
@@ -34,7 +59,7 @@ export const resolveGatsbyEndpoints = ({
         const endpointType = typeof endpoint === 'string' ? endpoint : endpoint.type;
         const endpointExt = typeof endpoint === 'string' ? allExt : endpoint.ext;
         const endpointFile = `gatsby-${endpointType}`;
-        const configFile = checkFileWithExts(path.join(configDir, endpointFile), endpointExt);
+        const configFile = checkFileWithExts(path.join(endpointRoot, endpointFile), endpointExt);
         if (configFile) {
             resolved[endpointType] = [configFile];
         }
@@ -50,7 +75,7 @@ export interface IMakeGatsbyEndpointProps {
     distDir: string;
     cacheDir: string;
 }
-export const browserSsr: IConfigTypes[] = ['browser', 'ssr'];
+
 
 /**
  * If defined `apiEndpoints` exist in the user's config directory,
@@ -69,7 +94,7 @@ export const setupGatsbyEndpoints = ({
     resolvedEndpoints,
     cacheDir,
 }: IMakeGatsbyEndpointProps): void => {
-    for (const setupApi of browserSsr) {
+    for (const setupApi of gatsbyEndpointProxies) {
         const endpointFile = `gatsby-${setupApi}.js`;
         const targetFile = path.join(cacheDir, endpointFile);
 
@@ -87,5 +112,53 @@ export const setupGatsbyEndpoints = ({
         }
         fs.ensureDirSync(path.dirname(targetFile));
         fs.writeFileSync(targetFile, moduleSrc);
+    }
+};
+
+// ***********************************************
+
+interface IResolvePluginPathProps {
+    projectRoot: string;
+    pluginName: string;
+}
+
+export const resolvePluginPath = ({
+    projectRoot,
+    pluginName,
+}: IResolvePluginPathProps): string => {
+    const scopedRequire = createRequire(projectRoot);
+    try {
+        const pluginPath = path.dirname(
+            scopedRequire.resolve(`${pluginName}/package.json`),
+        );
+        return pluginPath;
+    } catch (err) {
+        const localPluginsDir = path.resolve(projectRoot, 'plugins');
+        const pluginDir = path.join(localPluginsDir, pluginName);
+        if (isDir(path.join(localPluginsDir, pluginName))) {
+            const pkgJson = fileExists(path.join(pluginDir, 'package.json'));
+            if (pkgJson && pkgJson.isFile()) {
+                return pluginDir;
+            }
+        }
+        return '';
+    }
+};
+
+interface ICompilePluginsProps {
+    plugins: IPluginDetails[];
+}
+
+export const compilePlugins = ({
+    plugins,
+}: ICompilePluginsProps) => {
+    for (const pluginDetails of plugins) {
+        const pluginEndpoints = resolveGatsbyEndpoints({
+            endpointSpecs: configEndpointSpecs,
+            endpointRoot: pluginDetails.path,
+        });
+        for (const type of gatsbyConfigEndpoints) {
+            const pluginEndpointModule = tryRequireModule(type, pluginEndpoints, true, pluginDetails.name);
+        }
     }
 };

--- a/src/utils/fs-tools.ts
+++ b/src/utils/fs-tools.ts
@@ -18,14 +18,13 @@ export const getAbsoluteRelativeTo = (from: string, to?: string): string => {
     return absolute;
 };
 
-export const fileExists = (fPath: string): boolean => {
+export const fileExists = (fPath: string): fs.Stats | void => {
     try {
         const fStats = fs.statSync(fPath);
-        if (fStats) return true;
+        if (fStats) return fStats;
     } catch (err) {
         // noop
     }
-    return false;
 };
 
 export const checkFileWithExts = (fPath: string, extensions: IValidExts[] = allExt): string => {

--- a/src/utils/node.ts
+++ b/src/utils/node.ts
@@ -1,26 +1,32 @@
 import {
-    IConfigTypes,
+    createRequire as nodeCreateRequire,
+    createRequireFromPath as nodeCreateRequireFromPath,
+} from 'module';
+import RequireRegistrar from './register';
+import OptionsHandler from './options-handler';
+import { throwError } from "./errors";
+
+import type {
+    IGatsbyConfigTypes,
     IGatsbyEndpoints,
     IEndpointReturnTypes,
     IEndpointReturnObject,
     InferredConfigType,
 } from "../types";
-import RequireRegistrar from './register';
-import OptionsHandler from './options-handler';
-import { throwError } from "./errors";
 
 export const preferDefault = (compiled: any) => compiled && compiled.default || compiled;
 
-export const tryRequireModule = <T extends IConfigTypes = IConfigTypes>(
+export const tryRequireModule = <T extends IGatsbyConfigTypes = IGatsbyConfigTypes>(
     configType: T,
     endpoints?: IGatsbyEndpoints,
     startRegistrar = true,
+    pluginName?: string,
 ): IEndpointReturnTypes<T> => {
     if (!endpoints || !endpoints[configType]) return {} as IEndpointReturnTypes<T>;
     const modulePath = endpoints[configType]![0];
     let readModule = {} as IEndpointReturnTypes<T>;
     try {
-        if (startRegistrar) RequireRegistrar.start(configType);
+        if (startRegistrar) RequireRegistrar.start(configType, pluginName);
         readModule = preferDefault(require(modulePath));
     } catch (err) {
         throwError(`[gatsby-plugin-ts-config] An error occurred while reading your gatsby-${configType}!`, err);
@@ -44,3 +50,5 @@ export const getModuleObject: IGetModuleObject = (mod) => {
     return mod;
 
 };
+
+export const createRequire = nodeCreateRequire || nodeCreateRequireFromPath;

--- a/src/utils/options-handler.ts
+++ b/src/utils/options-handler.ts
@@ -4,14 +4,33 @@ import { keys } from 'ts-transformer-keys';
 import { TsConfigJson } from 'type-fest';
 import { TransformOptions as BabelTransformOptions } from '@babel/core';
 import { RegisterOptions as TSNodeRegisterOptions } from 'ts-node';
-import { IGlobalOpts, IPublicOpts, IConfigTypes } from "../types";
 import { addOptsToPreset } from './babel';
 import { getAbsoluteRelativeTo } from '../utils/fs-tools';
+import { compilePlugins } from './endpoints';
+
+import type {
+    IGlobalOpts,
+    IPublicOpts,
+    GatsbyEndpointResolverKeys,
+    IGatsbyPluginDef,
+    IGatsbyPluginWithOpts,
+    IPluginDetails,
+    IPluginDetailsCallback,
+} from "../types";
+import { resolvePluginPath } from './endpoints';
 
 const publicProps = keys<IPublicOpts>();
 
+export interface IResolvePlugins {
+    <T extends IGatsbyPluginDef = IGatsbyPluginDef>(plugins: IPluginDetailsCallback<T>): void;
+    <T extends IGatsbyPluginDef = IGatsbyPluginDef>(plugins: T[], pluginsCb?: IPluginDetailsCallback<T>): void;
+}
+
 class OptionsHandler {
     private opts = {} as IGlobalOpts;
+    private _plugins: IPluginDetails[] = [];
+    private _pluginCb: IPluginDetailsCallback[] = [];
+    private _extendedPlugins: IPluginDetails[] = [];
 
     public set(args: Partial<IGlobalOpts>) {
         this.opts = {
@@ -20,17 +39,110 @@ class OptionsHandler {
         };
     }
 
-    public addChainedImport(endpoint: IConfigTypes, filepath: string) {
+    private doResolvePlugins = <T extends IGatsbyPluginDef = IGatsbyPluginDef>(plugins: T[]): IPluginDetails[] => {
+        return plugins.reduce((acc, plugin) => {
+            const curPlugin = typeof plugin === 'string'
+                ? plugin as string
+                : plugin as IGatsbyPluginWithOpts;
+            const pluginDetails = (typeof curPlugin === 'string'
+                ? {
+                    name: curPlugin,
+                    options: {},
+                } : {
+                    name: curPlugin.resolve,
+                    options: curPlugin.options,
+                }) as IPluginDetails;
+            pluginDetails.path = resolvePluginPath({
+                projectRoot: this.opts.projectRoot,
+                pluginName: pluginDetails.name,
+            });
+            if (pluginDetails.path) {
+                acc.push(pluginDetails);
+            } else {
+                throw `[gatsby-plugin-ts-config] Unable to locate plugin ${pluginDetails.name}`;
+            }
+            return acc;
+        }, [] as IPluginDetails[]);
+    }
+
+    public doExtendPlugins = (compile = false): void => {
+        if (this.extendedPlugins.length > 0) return;
+        const pluginDetails = this._pluginCb.reduce((acc, pluginCb) => {
+            const plugins = this.doResolvePlugins(
+                pluginCb(this.public()),
+            );
+            if (compile) {
+                compilePlugins({
+                    plugins,
+                });
+            }
+            acc.push(...plugins);
+            return acc;
+        }, [] as IPluginDetails[]);
+        this._extendedPlugins.push(...pluginDetails);
+        this._plugins.push(...this._extendedPlugins);
+    }
+
+    public includePlugins: IResolvePlugins = <
+        T extends IGatsbyPluginDef = IGatsbyPluginDef
+    >(
+        plugins: T[] | IPluginDetailsCallback<T>,
+        pluginsCb?: IPluginDetailsCallback<T>,
+    ) => {
+        if (plugins instanceof Array) {
+            this._plugins.push(...this.doResolvePlugins(plugins));
+        } else {
+            this._pluginCb.push(plugins);
+        }
+        if (pluginsCb) {
+            this._pluginCb.push(pluginsCb);
+        }
+    }
+
+    private copyPlugins = (plugins: IPluginDetails[]): IPluginDetails[] => {
+        return [
+            ...plugins.map((plugin) => ({
+                ...plugin,
+            })),
+        ];
+    }
+    public get plugins(): IPluginDetails[] {
+        return this.copyPlugins(this._plugins);
+    }
+    public get extendedPlugins(): IPluginDetails[] {
+        return this.copyPlugins(this._extendedPlugins);
+    }
+
+    private addPluginChainedImport = (
+        endpoint: GatsbyEndpointResolverKeys,
+        name: string,
+        filePath: string,
+    ) => {
+        const endpoints = this.opts.endpoints;
+        if (!endpoints.plugin) endpoints.plugin = {};
+        if (!endpoints.plugin[name]) endpoints.plugin[name] = {};
+        if (!endpoints.plugin[name][endpoint]) endpoints.plugin[name][endpoint] = [];
+        endpoints.plugin[name][endpoint]?.push(filePath);
+    }
+
+    public addChainedImport = (
+        endpoint: GatsbyEndpointResolverKeys,
+        filepath: string,
+        pluginName?: string,
+    ) => {
+        if (pluginName) {
+            return this.addPluginChainedImport(endpoint, pluginName, filepath);
+        }
         if (!this.opts.endpoints[endpoint]) this.opts.endpoints[endpoint] = [];
         if (this.opts.endpoints[endpoint]![0] === filepath) return;
         this.opts.endpoints[endpoint]!.push(filepath);
     }
 
-    public get(): IGlobalOpts {
+    public get = (): IGlobalOpts => {
         return this.opts;
     }
 
-    public public(): IPublicOpts {
+    public public = (): IPublicOpts => {
         const entries = Object.entries(this.opts);
         const publicOpts = entries
             .filter(([key]) => publicProps.includes(key as keyof IPublicOpts))
@@ -41,13 +153,13 @@ class OptionsHandler {
         return publicOpts;
     }
 
-    private mergeOptionsWithConcat(to: any, from: any): any {
+    private mergeOptionsWithConcat = (to: any, from: any): any => {
         if (to instanceof Array) {
             return to.concat(from);
         }
     }
 
-    public setTsNodeOpts(opts: TSNodeRegisterOptions = {}): Required<IGlobalOpts>['tsNodeOpts'] {
+    public setTsNodeOpts = (opts: TSNodeRegisterOptions = {}): Required<IGlobalOpts>['tsNodeOpts'] => {
         const compilerOptions: TsConfigJson['compilerOptions'] = {
             module: "commonjs",
             target: "es2015",
@@ -72,7 +184,7 @@ class OptionsHandler {
         return this.opts.tsNodeOpts;
     }
 
-    public setBabelOpts(opts?: BabelTransformOptions): Required<IGlobalOpts>['babelOpts'] {
+    public setBabelOpts = (opts?: BabelTransformOptions): Required<IGlobalOpts>['babelOpts'] => {
         this.opts.babelOpts = mergeWith(
             {
                 sourceMaps: "inline",

--- a/src/utils/options-handler.ts
+++ b/src/utils/options-handler.ts
@@ -22,7 +22,7 @@ import { resolvePluginPath } from './endpoints';
 const publicProps = keys<IPublicOpts>();
 
 export interface IResolvePlugins {
-    <T extends IGatsbyPluginDef = IGatsbyPluginDef>(plugins: IPluginDetailsCallback<T>): void;
+    <T extends IGatsbyPluginDef = IGatsbyPluginDef>(plugins: T[] | IPluginDetailsCallback<T>): void;
     <T extends IGatsbyPluginDef = IGatsbyPluginDef>(plugins: T[], pluginsCb?: IPluginDetailsCallback<T>): void;
 }
 

--- a/src/utils/options-handler.ts
+++ b/src/utils/options-handler.ts
@@ -192,13 +192,14 @@ class OptionsHandler {
                 cwd: this.opts.projectRoot,
                 presets: [
                     require.resolve('@babel/preset-typescript'),
-                    addOptsToPreset(
-                        require('babel-preset-gatsby-package'),
-                        '@babel/plugin-transform-runtime',
-                        {
-                            absoluteRuntime: path.dirname(require.resolve('@babel/runtime/package.json')),
-                        },
-                    ),
+                    require.resolve('./preset'),
+                    // addOptsToPreset(
+                    //     require('babel-preset-gatsby-package'),
+                    //     '@babel/plugin-transform-runtime',
+                    //     {
+                    //         absoluteRuntime: path.dirname(require.resolve('@babel/runtime/package.json')),
+                    //     },
+                    // ),
                 ],
             },
             opts,

--- a/src/utils/options-handler.ts
+++ b/src/utils/options-handler.ts
@@ -1,10 +1,8 @@
-import * as path from 'path';
 import mergeWith from 'lodash.mergewith';
 import { keys } from 'ts-transformer-keys';
 import { TsConfigJson } from 'type-fest';
 import { TransformOptions as BabelTransformOptions } from '@babel/core';
 import { RegisterOptions as TSNodeRegisterOptions } from 'ts-node';
-import { addOptsToPreset } from './babel';
 import { getAbsoluteRelativeTo } from '../utils/fs-tools';
 import { compilePlugins } from './endpoints';
 

--- a/src/utils/preset.ts
+++ b/src/utils/preset.ts
@@ -46,9 +46,14 @@ const preset = () => {
         ].filter(Boolean),
         overrides: [
             {
-                test: [`**/*.ts`, `**/*.tsx`],
-                plugins: [[r(`@babel/plugin-transform-typescript`), { isTSX: true }]],
+                test: [`**/*.ts`],
+                presets: [[r(`@babel/preset-typescript`), { isTSX: false }]],
             },
+            {
+                test: [`**/*.tsx`],
+                presets: [[r(`@babel/preset-typescript`), { isTSX: true }]],
+            },
+            // test
         ],
     };
 };

--- a/src/utils/preset.ts
+++ b/src/utils/preset.ts
@@ -1,0 +1,56 @@
+import path from 'path';
+const r = (pkg: string): string => require.resolve(pkg);
+
+const preset = () => {
+    const nodeVersion = process.version.split('v')[1];
+    const { NODE_ENV, BABEL_ENV } = process.env;
+
+    const IS_TEST = (BABEL_ENV || NODE_ENV) === `test`;
+
+    const nodeConfig = {
+        corejs: 2,
+        useBuiltIns: `entry`,
+        targets: {
+            node: nodeVersion,
+        },
+    };
+
+    return {
+        presets: [
+            [
+                r(`@babel/preset-env`),
+                Object.assign(
+                    {
+                        loose: true,
+                        debug: false,
+                        shippedProposals: true,
+                        modules: `commonjs`,
+                    },
+                    nodeConfig,
+                ),
+            ],
+            r(`@babel/preset-react`),
+            r(`@babel/preset-flow`),
+        ],
+        plugins: [
+            r(`@babel/plugin-proposal-nullish-coalescing-operator`),
+            r(`@babel/plugin-proposal-optional-chaining`),
+            [
+                r(`@babel/plugin-transform-runtime`),
+                {
+                    absoluteRuntime: path.dirname(require.resolve('@babel/runtime/package.json')),
+                },
+            ],
+            r(`@babel/plugin-syntax-dynamic-import`),
+            IS_TEST && r(`babel-plugin-dynamic-import-node`),
+        ].filter(Boolean),
+        overrides: [
+            {
+                test: [`**/*.ts`, `**/*.tsx`],
+                plugins: [[r(`@babel/plugin-transform-typescript`), { isTSX: true }]],
+            },
+        ],
+    };
+};
+
+export = preset;

--- a/src/utils/preset.ts
+++ b/src/utils/preset.ts
@@ -53,7 +53,6 @@ const preset = () => {
                 test: [`**/*.tsx`],
                 presets: [[r(`@babel/preset-typescript`), { isTSX: true }]],
             },
-            // test
         ],
     };
 };

--- a/src/utils/register.ts
+++ b/src/utils/register.ts
@@ -8,6 +8,13 @@ import {
 } from '../types';
 import { throwError } from './errors';
 import optionsHandler from './options-handler';
+import BuiltinModule from 'module';
+
+interface IModule extends BuiltinModule {
+    _extensions: NodeJS.RequireExtensions;
+}
+
+const Module = BuiltinModule as unknown as IModule;
 
 export type IRegistrarProgramOpts = ICommonDirectories;
 
@@ -25,7 +32,9 @@ class RequireRegistrar<T extends IRegisterType> {
     private endpoint?: GatsbyEndpointResolverKeys;
     private pluginName?: string;
     private origExtensions = {
-        ...require.extensions,
+        ...Module._extensions,
+        '.ts': Module._extensions['.js'],
+        '.tsx': Module._extensions['.jsx'],
     }
 
     constructor() {
@@ -59,8 +68,7 @@ class RequireRegistrar<T extends IRegisterType> {
     public revert(): void {
         this.active = false;
         this.registered = false;
-        require.extensions = this.origExtensions;
-        // require.extensions['.ts'] = require.extensions['.js'];
+        Module._extensions = this.origExtensions;
     }
 
     private ignore(filename: string): boolean {

--- a/src/utils/register.ts
+++ b/src/utils/register.ts
@@ -1,6 +1,11 @@
 import { register } from 'ts-node';
 import babelRegister from '@babel/register';
-import { IRegisterOptions, IRegisterType, ICommonDirectories, IConfigTypes } from '../types';
+import {
+    IRegisterOptions,
+    IRegisterType,
+    ICommonDirectories,
+    GatsbyEndpointResolverKeys,
+} from '../types';
 import { throwError } from './errors';
 import optionsHandler from './options-handler';
 
@@ -17,7 +22,8 @@ class RequireRegistrar<T extends IRegisterType> {
     private type!: T;
     private registerOpts!: IRegisterOptions<T>;
     private extensions = ['.ts', '.tsx', '.js', '.jsx'];
-    private endpoint?: IConfigTypes;
+    private endpoint?: GatsbyEndpointResolverKeys;
+    private pluginName?: string;
     private origExtensions = {
         ...require.extensions,
     }
@@ -37,11 +43,12 @@ class RequireRegistrar<T extends IRegisterType> {
         this.initialized = true;
     }
 
-    public start(endpoint: IConfigTypes): void {
+    public start(endpoint: GatsbyEndpointResolverKeys, pluginName?: string): void {
         if (!this.initialized)
             throwError('[gatsby-plugin-ts-config] Compiler registration was started before it was initialized!', new Error());
         this.active = true;
         this.endpoint = endpoint;
+        this.pluginName = pluginName;
         if (!this.registered) this.register();
     }
 
@@ -53,13 +60,19 @@ class RequireRegistrar<T extends IRegisterType> {
         this.active = false;
         this.registered = false;
         require.extensions = this.origExtensions;
+        // require.extensions['.ts'] = require.extensions['.js'];
     }
 
     private ignore(filename: string): boolean {
         if (!this.active) return true;
         if (filename.indexOf('node_modules') > -1) return true;
         if (filename.endsWith('.pnp.js')) return true;
-        if (this.endpoint) optionsHandler.addChainedImport(this.endpoint, filename);
+        if (this.endpoint)
+            optionsHandler.addChainedImport(
+                this.endpoint,
+                filename,
+                this.pluginName,
+            );
         return false;
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "declaration": true,
     "outDir": "./dist",
-    "removeComments": true,
+    "removeComments": false,
     "skipLibCheck": true,
     "strict": true,
     "noImplicitAny": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/code-frame@npm:7.10.3"
+  dependencies:
+    "@babel/highlight": ^7.10.3
+  checksum: 2/83c618a1dabd1ad4d160daee00a50002fdca1969aed19f3b7d4440c14914974a0d3fa0662d2d1f1bfea3035ec397a3ed6126dc8f9469a8c99d45bcc4222a6516
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.10.1":
   version: 7.10.1
   resolution: "@babel/compat-data@npm:7.10.1"
@@ -30,6 +39,17 @@ __metadata:
     invariant: ^2.2.4
     semver: ^5.5.0
   checksum: 2/745fed72981104eb70132c04a2268f15bad5c2e10f83a698acb882040741af5605f2d079866860ab2aced518798a0032857c2f57eb532cef2a7e936986845fb9
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/compat-data@npm:7.10.3"
+  dependencies:
+    browserslist: ^4.12.0
+    invariant: ^2.2.4
+    semver: ^5.5.0
+  checksum: 2/d1b3f2ad44a91fa5571c922d2634a52351bc7d6556663e99008cb23071ba67f0ab13929449dd29ce7c14544e2528e117daf7db9781070d7ef49d8dc25909818a
   languageName: node
   linkType: hard
 
@@ -76,6 +96,18 @@ __metadata:
     lodash: ^4.17.13
     source-map: ^0.5.0
   checksum: 2/69e9d70293631ec1a58622411ae38e31cf8ef5969ff4ce3ae04a8fdad3225331d73856975c2d11fd485e830e9fb34235304b5e1955406aaa2f9d1a6c5a9f7b19
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/generator@npm:7.10.3"
+  dependencies:
+    "@babel/types": ^7.10.3
+    jsesc: ^2.5.1
+    lodash: ^4.17.13
+    source-map: ^0.5.0
+  checksum: 2/32bb6cc012aa76d8b07267fece363cb7cba0ac842cba0d2266bb67750381bd5f8697a98882dd4981189eccb59bfa95a23529655db536ff7ae34e678fca60a58a
   languageName: node
   linkType: hard
 
@@ -217,6 +249,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-create-class-features-plugin@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.10.3"
+  dependencies:
+    "@babel/helper-function-name": ^7.10.3
+    "@babel/helper-member-expression-to-functions": ^7.10.3
+    "@babel/helper-optimise-call-expression": ^7.10.3
+    "@babel/helper-plugin-utils": ^7.10.3
+    "@babel/helper-replace-supers": ^7.10.1
+    "@babel/helper-split-export-declaration": ^7.10.1
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 2/a1095c050c0503956d5c4716f9e01a8f12b6ef30dce24c646222029715b7a122ebe30e63a475e2e8f76fe0ada2b1918ddc6d1b026110706e516dbc629b587813
+  languageName: node
+  linkType: hard
+
 "@babel/helper-create-class-features-plugin@npm:^7.8.3":
   version: 7.8.6
   resolution: "@babel/helper-create-class-features-plugin@npm:7.8.6"
@@ -270,6 +318,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-define-map@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-define-map@npm:7.10.3"
+  dependencies:
+    "@babel/helper-function-name": ^7.10.3
+    "@babel/types": ^7.10.3
+    lodash: ^4.17.13
+  checksum: 2/530832dc7c02db641076101e8b82798d24ac484ccae314bc89ce63af2d96de2014d8a53a9bb3b98ec895881ebfea72eeffb0d8b2c8020d7409318eda044d0104
+  languageName: node
+  linkType: hard
+
 "@babel/helper-define-map@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/helper-define-map@npm:7.8.3"
@@ -312,6 +371,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-function-name@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-function-name@npm:7.10.3"
+  dependencies:
+    "@babel/helper-get-function-arity": ^7.10.3
+    "@babel/template": ^7.10.3
+    "@babel/types": ^7.10.3
+  checksum: 2/439ecb46f94d3a16de234c9b5ee963d5ade12c48290d8c1ef1e8175c3b780293a12a05a058f1eff41cbb392425d8806a46f80e0f1779fe4e82f622c069471730
+  languageName: node
+  linkType: hard
+
 "@babel/helper-function-name@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/helper-function-name@npm:7.8.3"
@@ -329,6 +399,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.10.1
   checksum: 2/631af96439202578620476a2c712a5afeb67f30e73b33dc76d26e941f28783ad781a8366b9c3c69dcbeef9ee8e7b10e41d42e27418c54b23124c349b2b73f4d8
+  languageName: node
+  linkType: hard
+
+"@babel/helper-get-function-arity@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-get-function-arity@npm:7.10.3"
+  dependencies:
+    "@babel/types": ^7.10.3
+  checksum: 2/334e09070c45874019f3aedde80831778f9845aa622f91d365c7d621662dd4339aad0e2456688ebcc9ff17876bc4b072b8b87837bc94527c527e0b206e0b02ec
   languageName: node
   linkType: hard
 
@@ -350,6 +429,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-hoist-variables@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-hoist-variables@npm:7.10.3"
+  dependencies:
+    "@babel/types": ^7.10.3
+  checksum: 2/267f89303dfbd61879be0e655adbb6261db465f2869786be5c6d8110dbf04da0edfa3cd90d9490c5b754844d720a55854b7ad94b0e2d33741fb7faf949a79bdc
+  languageName: node
+  linkType: hard
+
 "@babel/helper-hoist-variables@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/helper-hoist-variables@npm:7.8.3"
@@ -368,6 +456,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-member-expression-to-functions@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.10.3"
+  dependencies:
+    "@babel/types": ^7.10.3
+  checksum: 2/3d92522983e068e72ac97413f79b361a197ca1148cd2c3cbff908edfe7c3c5167f57649b485eaf2ce7b3ee1dd637a2fe013c2e936e12385723234667e59878a6
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/helper-member-expression-to-functions@npm:7.8.3"
@@ -383,6 +480,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.10.1
   checksum: 2/83dde1cadb538c2c395aafdbd54b968828395b58d1e399513771c610c82b1e64eca684c598e465f81a43c36247d6def25b3a22ab7038fedd25224c60998182d9
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-module-imports@npm:7.10.3"
+  dependencies:
+    "@babel/types": ^7.10.3
+  checksum: 2/831629d4701d19085c35717a9d21fb0971f8f1b98d9a7e23a5ad7639c1af8e292e6b3e52e7cc92008df89a5aaf21b1ebdca77acdf2a8afe5535eca66878619db
   languageName: node
   linkType: hard
 
@@ -434,6 +540,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-optimise-call-expression@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-optimise-call-expression@npm:7.10.3"
+  dependencies:
+    "@babel/types": ^7.10.3
+  checksum: 2/931ebea991b4aa5242c6e840209c2ca9b88dd068d29f4a8aef703c772766b5c684fa5f7f6d8a0845740f9fc6c330dcd31fa89b56eea6edfeb4152e5d6b036634
+  languageName: node
+  linkType: hard
+
 "@babel/helper-optimise-call-expression@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/helper-optimise-call-expression@npm:7.8.3"
@@ -447,6 +562,13 @@ __metadata:
   version: 7.10.1
   resolution: "@babel/helper-plugin-utils@npm:7.10.1"
   checksum: 2/31635ce61833ff17a10588b62d028b7e444bcf1c0d440ad7efe0512ea77027d84e44cd5e483b0ae62965e66566d388cd4f1d28c4a31d1c8e9e221ab7e530a53f
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-plugin-utils@npm:7.10.3"
+  checksum: 2/eaa3cbfb41fc1fb6a64f6612af9315bbc877e136e49b2dd62e6ac00d3ebd3f727d92d1112cafb19d981c5c00423ae78fd49b661214d3bf0d206820358ce870a1
   languageName: node
   linkType: hard
 
@@ -485,6 +607,19 @@ __metadata:
     "@babel/traverse": ^7.10.1
     "@babel/types": ^7.10.1
   checksum: 2/ee91f2c128db021937298d5a41c233fda5c3b47aae09bd8dd2f78c1bd8256126c1332b94ad57935e40305b53358fbef7f5bd6b9cdf354f17dd2255d6bc95f6b6
+  languageName: node
+  linkType: hard
+
+"@babel/helper-remap-async-to-generator@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-remap-async-to-generator@npm:7.10.3"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.10.1
+    "@babel/helper-wrap-function": ^7.10.1
+    "@babel/template": ^7.10.3
+    "@babel/traverse": ^7.10.3
+    "@babel/types": ^7.10.3
+  checksum: 2/4fa0c3eb4b49ca03fcc3dd97b0657a8ccc32a1ba7301afdbe9cadf9f1494d0acb1f59f56e261c9a7818741bab63e3f8c986a72c43d92a0482b41a4288f75bf3e
   languageName: node
   linkType: hard
 
@@ -570,6 +705,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/helper-validator-identifier@npm:7.10.3"
+  checksum: 2/0eb0b199eba82b61e9bc979f6ed1ee669e6796ad0fa914c7b829c32b879af504cf928687683455c3e58ef8c0707e35c88cab84ed4635c05cd3076ed5684b5cc3
+  languageName: node
+  linkType: hard
+
 "@babel/helper-wrap-function@npm:^7.10.1":
   version: 7.10.1
   resolution: "@babel/helper-wrap-function@npm:7.10.1"
@@ -616,6 +758,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/highlight@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/highlight@npm:7.10.3"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.10.3
+    chalk: ^2.0.0
+    js-tokens: ^4.0.0
+  checksum: 2/e16cf08acc870cbc4f355519ce92df0d285f69d04da669f809a2cd8d0fe9070408768a19822fd623f16ce0c86c9c248489e7b191085acd3ac69dccc9c6c9a930
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/highlight@npm:7.8.3"
@@ -645,6 +798,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/parser@npm:7.10.3"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 2/e6ca5dd22f0effc4fdd5bba50528c940a192300340d06da5b2d2bda22ea30c22ad6c988a3dcfbb0c8b6920d96d9db477fc186fc9b1e425e29443cc7d9df3851d
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-async-generator-functions@npm:^7.10.1":
   version: 7.10.1
   resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.10.1"
@@ -655,6 +817,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/9fa97c8a33fd725ce9b5f447b319c1eea9f45cdb2bb67f238c2a4ebcd3ff69551e04fcaecf92763e5aff989dffa66f664e429f18af2404704804e8b094d4f5f2
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-async-generator-functions@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.10.3"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.3
+    "@babel/helper-remap-async-to-generator": ^7.10.3
+    "@babel/plugin-syntax-async-generators": ^7.8.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/c4140379192a75f02f12d92932837a18513574e4a2e0ec41ca564a63fd0760b4362ba5e4a001ac01aca2c373ef3c8e46be3487c749a3193d5ec00502523419c4
   languageName: node
   linkType: hard
 
@@ -792,6 +967,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-object-rest-spread@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.10.3"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.3
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.0
+    "@babel/plugin-transform-parameters": ^7.10.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/f9c499730456313ff3973803480c68a5309f28573d7ed66eda0bd774709039a5d57f032fe8583c8609bbb560283653d227defa890f101935cbb94139e5c7cf26
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-object-rest-spread@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.8.3"
@@ -837,6 +1025,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/d06c8b7c8fad8ed24cb89a66ec1a274980bb35f3f3d3c5bf2aa00ce5fb58867cee1adf8f008b83fd60b23096aa8f71970ff51869a6cd7a8777eac27290880489
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-optional-chaining@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-proposal-optional-chaining@npm:7.10.3"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.3
+    "@babel/plugin-syntax-optional-chaining": ^7.8.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/fbeffd5cb06df853e1a7c53b7c713ed1f2abd89abbd85f90679446ae285e14744887f997f87c20ddcadb5048b2164dc0077294ed08cc5ff287ce2c4701aa6d8a
   languageName: node
   linkType: hard
 
@@ -1176,6 +1376,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-classes@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-transform-classes@npm:7.10.3"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.10.1
+    "@babel/helper-define-map": ^7.10.3
+    "@babel/helper-function-name": ^7.10.3
+    "@babel/helper-optimise-call-expression": ^7.10.3
+    "@babel/helper-plugin-utils": ^7.10.3
+    "@babel/helper-replace-supers": ^7.10.1
+    "@babel/helper-split-export-declaration": ^7.10.1
+    globals: ^11.1.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/2548575c1f23a8e7ecbafeee35a3cdaff3236dd7eac96d310a53eda29a3328614b544eec0397c5812e3581a61b281942f0aa81378149a86022bf16e16b91f323
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-classes@npm:^7.8.6":
   version: 7.8.6
   resolution: "@babel/plugin-transform-classes@npm:7.8.6"
@@ -1202,6 +1420,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/e30b91ef81a0eadacb1a3aa77c1392f3422dd851d6264ac29d57aebdc88fe0ebd782a4b56e36f1671d1e3a7017317ab3011ec680c05a0f9c16e86a5feb1d94df
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-computed-properties@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-transform-computed-properties@npm:7.10.3"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/a8cfa3647c864c840905013c0c2c6cd74b06de2dfe46b4d2be2e602caf0d1bcc9755004a5082abcd2c12de67dd0c46d27188e7b08a6ca5f415984b639696370d
   languageName: node
   linkType: hard
 
@@ -1478,6 +1707,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-modules-systemjs@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.10.3"
+  dependencies:
+    "@babel/helper-hoist-variables": ^7.10.3
+    "@babel/helper-module-transforms": ^7.10.1
+    "@babel/helper-plugin-utils": ^7.10.3
+    babel-plugin-dynamic-import-node: ^2.3.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/635e9b09773fe9984c7ae18321cb410cfda2185e86583b9e52d3fb87dbe37d05cca047468cd8d4a1595f186cd3a911c64aad1bf119ca8d210146bccbd770e1c5
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-modules-systemjs@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/plugin-transform-modules-systemjs@npm:7.8.3"
@@ -1513,6 +1756,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/4a51a179eb7bcc5e3242dcabcd13151f54d53e1324a06db76a5e4254b7ed0630e2b02d0c951b0805f24c603efc545ef2e950861a3a4ad2c8a2f6389146c13a66
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.10.3"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": ^7.8.3
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 2/0e2936f88f25d3b2843306824f3ec9608ed8402ecb1dd8a1d1542914b6f4cdcb75e0323083fdf7b8c7854fabe3d60350b3b2387f92cf83b0b5844d16db359dcf
   languageName: node
   linkType: hard
 
@@ -1753,6 +2007,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-regenerator@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-transform-regenerator@npm:7.10.3"
+  dependencies:
+    regenerator-transform: ^0.14.2
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/6b1270d294ace95220a19fe239480a4b2c2d4ce4716cbfdbb3a7e5df9a68c193d6fc8089010a658ed20e35b086d5de6f817aaeb5fc4e09f24e34edb5ece09104
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-regenerator@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/plugin-transform-regenerator@npm:7.8.3"
@@ -1797,6 +2062,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/170fb19b66968338c7ab0c7bdc393e44dab0ca6869b6982a105d011978f1e41d3a1a164dac1ef2b6213dc74ef8a733f782a643ad9405bfa7899010d785976912
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-runtime@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-transform-runtime@npm:7.10.3"
+  dependencies:
+    "@babel/helper-module-imports": ^7.10.3
+    "@babel/helper-plugin-utils": ^7.10.3
+    resolve: ^1.8.1
+    semver: ^5.5.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/02ee43fd5ba1f1770497ded75e1910dfd709a5cee2a29475e6222c61f7e68de68385dad3b268406e3dd2d6da74a46e208014433f8d7be94d7e997b4c0111078f
   languageName: node
   linkType: hard
 
@@ -1894,6 +2173,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-template-literals@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-transform-template-literals@npm:7.10.3"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.10.1
+    "@babel/helper-plugin-utils": ^7.10.3
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/6892c8500b019efe4eb47dbc02ab14e16598b40d5c2367b51d46abf68fe2b72ca8007d0383e28e1863fa0f8493fceb95569f09cb349087adb54774f2d2b26162
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-template-literals@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/plugin-transform-template-literals@npm:7.8.3"
@@ -1938,6 +2229,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/f89cda5eb38b60eac4ad274efc23d3ebca9859e7506640a431773593880874f125e2eac041959da101804a1c6dd9958630bc99d2b62d1c61c72222ba09ca7bb5
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-typescript@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/plugin-transform-typescript@npm:7.10.3"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.10.3
+    "@babel/helper-plugin-utils": ^7.10.3
+    "@babel/plugin-syntax-typescript": ^7.10.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/39c7bfd437d8367968abd57703c275640919636a95040ca4bae7bdd3eb1c0e748c99f0703fa29f0755af88b70743361cb4f5e8b0969b62012b06a33f0507cda2
   languageName: node
   linkType: hard
 
@@ -2070,6 +2374,80 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/e74276ebc78dbf405e3e7b29bb609b6971a15f94ec05bc443077edd3c05c17a3c0c110da64509608d2557797e80ae867ea189da27e5b1d101652a45f856543e9
+  languageName: node
+  linkType: hard
+
+"@babel/preset-env@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/preset-env@npm:7.10.3"
+  dependencies:
+    "@babel/compat-data": ^7.10.3
+    "@babel/helper-compilation-targets": ^7.10.2
+    "@babel/helper-module-imports": ^7.10.3
+    "@babel/helper-plugin-utils": ^7.10.3
+    "@babel/plugin-proposal-async-generator-functions": ^7.10.3
+    "@babel/plugin-proposal-class-properties": ^7.10.1
+    "@babel/plugin-proposal-dynamic-import": ^7.10.1
+    "@babel/plugin-proposal-json-strings": ^7.10.1
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.10.1
+    "@babel/plugin-proposal-numeric-separator": ^7.10.1
+    "@babel/plugin-proposal-object-rest-spread": ^7.10.3
+    "@babel/plugin-proposal-optional-catch-binding": ^7.10.1
+    "@babel/plugin-proposal-optional-chaining": ^7.10.3
+    "@babel/plugin-proposal-private-methods": ^7.10.1
+    "@babel/plugin-proposal-unicode-property-regex": ^7.10.1
+    "@babel/plugin-syntax-async-generators": ^7.8.0
+    "@babel/plugin-syntax-class-properties": ^7.10.1
+    "@babel/plugin-syntax-dynamic-import": ^7.8.0
+    "@babel/plugin-syntax-json-strings": ^7.8.0
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.0
+    "@babel/plugin-syntax-numeric-separator": ^7.10.1
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.0
+    "@babel/plugin-syntax-optional-catch-binding": ^7.8.0
+    "@babel/plugin-syntax-optional-chaining": ^7.8.0
+    "@babel/plugin-syntax-top-level-await": ^7.10.1
+    "@babel/plugin-transform-arrow-functions": ^7.10.1
+    "@babel/plugin-transform-async-to-generator": ^7.10.1
+    "@babel/plugin-transform-block-scoped-functions": ^7.10.1
+    "@babel/plugin-transform-block-scoping": ^7.10.1
+    "@babel/plugin-transform-classes": ^7.10.3
+    "@babel/plugin-transform-computed-properties": ^7.10.3
+    "@babel/plugin-transform-destructuring": ^7.10.1
+    "@babel/plugin-transform-dotall-regex": ^7.10.1
+    "@babel/plugin-transform-duplicate-keys": ^7.10.1
+    "@babel/plugin-transform-exponentiation-operator": ^7.10.1
+    "@babel/plugin-transform-for-of": ^7.10.1
+    "@babel/plugin-transform-function-name": ^7.10.1
+    "@babel/plugin-transform-literals": ^7.10.1
+    "@babel/plugin-transform-member-expression-literals": ^7.10.1
+    "@babel/plugin-transform-modules-amd": ^7.10.1
+    "@babel/plugin-transform-modules-commonjs": ^7.10.1
+    "@babel/plugin-transform-modules-systemjs": ^7.10.3
+    "@babel/plugin-transform-modules-umd": ^7.10.1
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.10.3
+    "@babel/plugin-transform-new-target": ^7.10.1
+    "@babel/plugin-transform-object-super": ^7.10.1
+    "@babel/plugin-transform-parameters": ^7.10.1
+    "@babel/plugin-transform-property-literals": ^7.10.1
+    "@babel/plugin-transform-regenerator": ^7.10.3
+    "@babel/plugin-transform-reserved-words": ^7.10.1
+    "@babel/plugin-transform-shorthand-properties": ^7.10.1
+    "@babel/plugin-transform-spread": ^7.10.1
+    "@babel/plugin-transform-sticky-regex": ^7.10.1
+    "@babel/plugin-transform-template-literals": ^7.10.3
+    "@babel/plugin-transform-typeof-symbol": ^7.10.1
+    "@babel/plugin-transform-unicode-escapes": ^7.10.1
+    "@babel/plugin-transform-unicode-regex": ^7.10.1
+    "@babel/preset-modules": ^0.1.3
+    "@babel/types": ^7.10.3
+    browserslist: ^4.12.0
+    core-js-compat: ^3.6.2
+    invariant: ^2.2.2
+    levenary: ^1.1.1
+    semver: ^5.5.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2/02919266f17ea26c47950c12db4d40c55b0b835d565db4419415d3b569a67d748a877921445845e4a181493d24ce0df3ab5f224918de89f2be05132f0c091aff
   languageName: node
   linkType: hard
 
@@ -2255,6 +2633,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/template@npm:7.10.3"
+  dependencies:
+    "@babel/code-frame": ^7.10.3
+    "@babel/parser": ^7.10.3
+    "@babel/types": ^7.10.3
+  checksum: 2/1b2df7f93f3505b221574b439e503e926ae3a91b28f4ff2f66e25a9bd74d8cd473d1086e36edcbe34f4198b138785fca76ba613082e9da5eea43eddf9f143b28
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.8.3, @babel/template@npm:^7.8.6":
   version: 7.8.6
   resolution: "@babel/template@npm:7.8.6"
@@ -2280,6 +2669,23 @@ __metadata:
     globals: ^11.1.0
     lodash: ^4.17.13
   checksum: 2/d9903e00143bc21a2cf34a283689f365fb25c06ac6c7e904463d8a2f531d33766e77ad1e28a6de87affe0ce1c7bc3e8caab84567ee734a9640581764c8a909ed
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/traverse@npm:7.10.3"
+  dependencies:
+    "@babel/code-frame": ^7.10.3
+    "@babel/generator": ^7.10.3
+    "@babel/helper-function-name": ^7.10.3
+    "@babel/helper-split-export-declaration": ^7.10.1
+    "@babel/parser": ^7.10.3
+    "@babel/types": ^7.10.3
+    debug: ^4.1.0
+    globals: ^11.1.0
+    lodash: ^4.17.13
+  checksum: 2/cfe64b335777bfc57633b50aaf219ed53f49be40eefd82c11d9182d40ba2a16f523368ff57f9a5df88f41bbf65ed89f1c1d0caab1170eaebe05f0b94c7c9781e
   languageName: node
   linkType: hard
 
@@ -2319,6 +2725,17 @@ __metadata:
     lodash: ^4.17.13
     to-fast-properties: ^2.0.0
   checksum: 2/cebcac3d3f083458fa671aef3a4d5346df86e5376cefe9b734dd7ae6a84f19935d588d07db450af56773aa995a440b80916d55da6f0c5c14f0755734b3fbe505
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.10.3":
+  version: 7.10.3
+  resolution: "@babel/types@npm:7.10.3"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.10.3
+    lodash: ^4.17.13
+    to-fast-properties: ^2.0.0
+  checksum: 2/7c41a5a0e66b7ccd002cc9e395ccd269c6a1e94035193f66f021cca0880c9e999eb1a25fa363e4295a4a5b5b3653a8f5bb13bf2d0abc9e8e427ad9aaedcf1935
   languageName: node
   linkType: hard
 
@@ -7356,6 +7773,14 @@ fsevents@~2.1.1:
   resolution: "gatsby-plugin-ts-config@workspace:."
   dependencies:
     "@babel/core": ^7.8.6
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.10.1
+    "@babel/plugin-proposal-optional-chaining": ^7.10.3
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-transform-runtime": ^7.10.3
+    "@babel/plugin-transform-typescript": ^7.10.3
+    "@babel/preset-env": ^7.10.3
+    "@babel/preset-flow": ^7.10.1
+    "@babel/preset-react": ^7.10.1
     "@babel/preset-typescript": ^7.8.3
     "@babel/register": ^7.8.6
     "@babel/runtime": ^7.8.7
@@ -7369,6 +7794,7 @@ fsevents@~2.1.1:
     "@typescript-eslint/parser": ^2.21.0
     "@typescript-eslint/typescript-estree": ^2.21.0
     "@yarnpkg/pnpify": ^2.0.0-rc.18
+    babel-plugin-dynamic-import-node: ^2.3.3
     babel-preset-gatsby-package: ^0.4.4
     eslint: ^6.8.0
     fs-extra: ^8.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,17 +307,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-define-map@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/helper-define-map@npm:7.10.1"
-  dependencies:
-    "@babel/helper-function-name": ^7.10.1
-    "@babel/types": ^7.10.1
-    lodash: ^4.17.13
-  checksum: 2/bf85f9b8c25d5b7b01070d50cb11185702956bdd16265184512da4462dfb655d7a8a9fa274295eeff8f2779e65d218a237b0a722201d6fc6ded57bb2fdaba23c
-  languageName: node
-  linkType: hard
-
 "@babel/helper-define-map@npm:^7.10.3":
   version: 7.10.3
   resolution: "@babel/helper-define-map@npm:7.10.3"
@@ -417,15 +406,6 @@ __metadata:
   dependencies:
     "@babel/types": ^7.8.3
   checksum: 2/173ce64f2bc357ca6deb6c639c02fc3842b9c88750501decfe1fa3b7cfe449280f1ced0b7d754a9bf338e7227300af3b28a3447d60048dfceb6405c017b0b84b
-  languageName: node
-  linkType: hard
-
-"@babel/helper-hoist-variables@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/helper-hoist-variables@npm:7.10.1"
-  dependencies:
-    "@babel/types": ^7.10.1
-  checksum: 2/8881f1aa940bdd1d8761b6c6d889f27430db0b66e72b8208ee4e46296c8ca8ddcce3787c30c52959f4bc06399cf3e376d005bbb056bf82444a43bd75ecfac87f
   languageName: node
   linkType: hard
 
@@ -807,19 +787,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-async-generator-functions@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.10.1"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.10.1
-    "@babel/helper-remap-async-to-generator": ^7.10.1
-    "@babel/plugin-syntax-async-generators": ^7.8.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/9fa97c8a33fd725ce9b5f447b319c1eea9f45cdb2bb67f238c2a4ebcd3ff69551e04fcaecf92763e5aff989dffa66f664e429f18af2404704804e8b094d4f5f2
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-proposal-async-generator-functions@npm:^7.10.3":
   version: 7.10.3
   resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.10.3"
@@ -954,19 +921,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-object-rest-spread@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.10.1"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.10.1
-    "@babel/plugin-syntax-object-rest-spread": ^7.8.0
-    "@babel/plugin-transform-parameters": ^7.10.1
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/5a03728f6d10f6f01188c3807a2ae9fcd364e3494825c1fcacf497992217512596f24f4b21dcc3eef69530379ddc5f0df6595160f57bcf10ae35f30e59164470
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-proposal-object-rest-spread@npm:^7.10.3":
   version: 7.10.3
   resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.10.3"
@@ -1013,18 +967,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/6241b347b611e91f436022649def5f08359608db5b9b133c4d32ab8ac1e5d693bd95799e6bfd9dac4f641f561ca9f65f424f7813ffaddf33b88878bfe2714107
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-proposal-optional-chaining@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/plugin-proposal-optional-chaining@npm:7.10.1"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.10.1
-    "@babel/plugin-syntax-optional-chaining": ^7.8.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/d06c8b7c8fad8ed24cb89a66ec1a274980bb35f3f3d3c5bf2aa00ce5fb58867cee1adf8f008b83fd60b23096aa8f71970ff51869a6cd7a8777eac27290880489
   languageName: node
   linkType: hard
 
@@ -1358,24 +1300,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-classes@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/plugin-transform-classes@npm:7.10.1"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.10.1
-    "@babel/helper-define-map": ^7.10.1
-    "@babel/helper-function-name": ^7.10.1
-    "@babel/helper-optimise-call-expression": ^7.10.1
-    "@babel/helper-plugin-utils": ^7.10.1
-    "@babel/helper-replace-supers": ^7.10.1
-    "@babel/helper-split-export-declaration": ^7.10.1
-    globals: ^11.1.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/8eed0671f51ba3ef675504b7914318f4bd2e50d75ef17d1c6ad7ad4f4fa0abc60b71fb5a5d0afb505c87e64a0ae589fbfb0696ef391a9c7d350a508aea793ac7
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-transform-classes@npm:^7.10.3":
   version: 7.10.3
   resolution: "@babel/plugin-transform-classes@npm:7.10.3"
@@ -1409,17 +1333,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/d74effa46f943bd682b97fa89c58735cf16cb814b6b0f7283bcf3e3bdc3ace63cbb988b04bc2df0d4bf4772c013aca64e01fc6d2efaf6c4f2284351d7a1aee2b
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-computed-properties@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/plugin-transform-computed-properties@npm:7.10.1"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.10.1
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/e30b91ef81a0eadacb1a3aa77c1392f3422dd851d6264ac29d57aebdc88fe0ebd782a4b56e36f1671d1e3a7017317ab3011ec680c05a0f9c16e86a5feb1d94df
   languageName: node
   linkType: hard
 
@@ -1690,20 +1603,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/880ee92eff8f6dd944b1865a980d9f304ed9f1b8c7139bd14be1e26c8ad1b7825521eab866b73b6cd5efab93c4f329f85777a5873126e6b31b51cc9792d5fed6
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-modules-systemjs@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.10.1"
-  dependencies:
-    "@babel/helper-hoist-variables": ^7.10.1
-    "@babel/helper-module-transforms": ^7.10.1
-    "@babel/helper-plugin-utils": ^7.10.1
-    babel-plugin-dynamic-import-node: ^2.3.3
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/76577bf1aca5daf35a0792415c9bf109b38e1a35dbd4a5ec521dc77b5d1977bf916d0a610356cd153bffc10d5d9f91cbaeb5e3a698a77d132d2586cca58a0e20
   languageName: node
   linkType: hard
 
@@ -1996,17 +1895,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-regenerator@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/plugin-transform-regenerator@npm:7.10.1"
-  dependencies:
-    regenerator-transform: ^0.14.2
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/da9cf9450b0805c84e50fa63f4645bd59220280819be7942880862abef01d4f428706a283fb61f7a02ad15fa284cdb4ac6116b21493378e1fe4f4cc75046e223
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-transform-regenerator@npm:^7.10.3":
   version: 7.10.3
   resolution: "@babel/plugin-transform-regenerator@npm:7.10.3"
@@ -2048,20 +1936,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/0a291ec7673cc4fffb7ba461cb2d2a9fcb3f53d22399900e4b80dd35cbae785e62758bd81461e4f0783727bdd715a82dad65663022f52750b93d6e771ca4a39f
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-runtime@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/plugin-transform-runtime@npm:7.10.1"
-  dependencies:
-    "@babel/helper-module-imports": ^7.10.1
-    "@babel/helper-plugin-utils": ^7.10.1
-    resolve: ^1.8.1
-    semver: ^5.5.1
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/170fb19b66968338c7ab0c7bdc393e44dab0ca6869b6982a105d011978f1e41d3a1a164dac1ef2b6213dc74ef8a733f782a643ad9405bfa7899010d785976912
   languageName: node
   linkType: hard
 
@@ -2161,18 +2035,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-template-literals@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/plugin-transform-template-literals@npm:7.10.1"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.10.1
-    "@babel/helper-plugin-utils": ^7.10.1
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/fdad2f5766d3b8e830850c030f27f1caa3535b7ad997e8324dfc2a0bb5979df2668afec8a8a3e013767f91be2b501e964a4e235764e929b55c95813427100266
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-transform-template-literals@npm:^7.10.3":
   version: 7.10.3
   resolution: "@babel/plugin-transform-template-literals@npm:7.10.3"
@@ -2216,19 +2078,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2/1ea7cacb9c1c4b8b366dcc9a15a09d17f57b2a7c03e70a3eb2824891e1c86d51883d28868873537d66ffbb2d19882634fc65ea58caabe1b604fcb629e66e3af4
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-typescript@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@babel/plugin-transform-typescript@npm:7.10.1"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.10.1
-    "@babel/helper-plugin-utils": ^7.10.1
-    "@babel/plugin-syntax-typescript": ^7.10.1
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/f89cda5eb38b60eac4ad274efc23d3ebca9859e7506640a431773593880874f125e2eac041959da101804a1c6dd9958630bc99d2b62d1c61c72222ba09ca7bb5
   languageName: node
   linkType: hard
 
@@ -2300,80 +2149,6 @@ __metadata:
     core-js: ^2.6.5
     regenerator-runtime: ^0.13.2
   checksum: 2/6881d5da1edc42f4d314f6851af179d18bc0b96578b2e2d6af961d79b0614f48e325a2c9617e430027659b36e553e02bc13c6a323ad6ec0556ddb5f62f04b48c
-  languageName: node
-  linkType: hard
-
-"@babel/preset-env@npm:^7.10.2":
-  version: 7.10.2
-  resolution: "@babel/preset-env@npm:7.10.2"
-  dependencies:
-    "@babel/compat-data": ^7.10.1
-    "@babel/helper-compilation-targets": ^7.10.2
-    "@babel/helper-module-imports": ^7.10.1
-    "@babel/helper-plugin-utils": ^7.10.1
-    "@babel/plugin-proposal-async-generator-functions": ^7.10.1
-    "@babel/plugin-proposal-class-properties": ^7.10.1
-    "@babel/plugin-proposal-dynamic-import": ^7.10.1
-    "@babel/plugin-proposal-json-strings": ^7.10.1
-    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.10.1
-    "@babel/plugin-proposal-numeric-separator": ^7.10.1
-    "@babel/plugin-proposal-object-rest-spread": ^7.10.1
-    "@babel/plugin-proposal-optional-catch-binding": ^7.10.1
-    "@babel/plugin-proposal-optional-chaining": ^7.10.1
-    "@babel/plugin-proposal-private-methods": ^7.10.1
-    "@babel/plugin-proposal-unicode-property-regex": ^7.10.1
-    "@babel/plugin-syntax-async-generators": ^7.8.0
-    "@babel/plugin-syntax-class-properties": ^7.10.1
-    "@babel/plugin-syntax-dynamic-import": ^7.8.0
-    "@babel/plugin-syntax-json-strings": ^7.8.0
-    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.0
-    "@babel/plugin-syntax-numeric-separator": ^7.10.1
-    "@babel/plugin-syntax-object-rest-spread": ^7.8.0
-    "@babel/plugin-syntax-optional-catch-binding": ^7.8.0
-    "@babel/plugin-syntax-optional-chaining": ^7.8.0
-    "@babel/plugin-syntax-top-level-await": ^7.10.1
-    "@babel/plugin-transform-arrow-functions": ^7.10.1
-    "@babel/plugin-transform-async-to-generator": ^7.10.1
-    "@babel/plugin-transform-block-scoped-functions": ^7.10.1
-    "@babel/plugin-transform-block-scoping": ^7.10.1
-    "@babel/plugin-transform-classes": ^7.10.1
-    "@babel/plugin-transform-computed-properties": ^7.10.1
-    "@babel/plugin-transform-destructuring": ^7.10.1
-    "@babel/plugin-transform-dotall-regex": ^7.10.1
-    "@babel/plugin-transform-duplicate-keys": ^7.10.1
-    "@babel/plugin-transform-exponentiation-operator": ^7.10.1
-    "@babel/plugin-transform-for-of": ^7.10.1
-    "@babel/plugin-transform-function-name": ^7.10.1
-    "@babel/plugin-transform-literals": ^7.10.1
-    "@babel/plugin-transform-member-expression-literals": ^7.10.1
-    "@babel/plugin-transform-modules-amd": ^7.10.1
-    "@babel/plugin-transform-modules-commonjs": ^7.10.1
-    "@babel/plugin-transform-modules-systemjs": ^7.10.1
-    "@babel/plugin-transform-modules-umd": ^7.10.1
-    "@babel/plugin-transform-named-capturing-groups-regex": ^7.8.3
-    "@babel/plugin-transform-new-target": ^7.10.1
-    "@babel/plugin-transform-object-super": ^7.10.1
-    "@babel/plugin-transform-parameters": ^7.10.1
-    "@babel/plugin-transform-property-literals": ^7.10.1
-    "@babel/plugin-transform-regenerator": ^7.10.1
-    "@babel/plugin-transform-reserved-words": ^7.10.1
-    "@babel/plugin-transform-shorthand-properties": ^7.10.1
-    "@babel/plugin-transform-spread": ^7.10.1
-    "@babel/plugin-transform-sticky-regex": ^7.10.1
-    "@babel/plugin-transform-template-literals": ^7.10.1
-    "@babel/plugin-transform-typeof-symbol": ^7.10.1
-    "@babel/plugin-transform-unicode-escapes": ^7.10.1
-    "@babel/plugin-transform-unicode-regex": ^7.10.1
-    "@babel/preset-modules": ^0.1.3
-    "@babel/types": ^7.10.2
-    browserslist: ^4.12.0
-    core-js-compat: ^3.6.2
-    invariant: ^2.2.2
-    levenary: ^1.1.1
-    semver: ^5.5.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 2/e74276ebc78dbf405e3e7b29bb609b6971a15f94ec05bc443077edd3c05c17a3c0c110da64509608d2557797e80ae867ea189da27e5b1d101652a45f856543e9
   languageName: node
   linkType: hard
 
@@ -4164,26 +3939,6 @@ __metadata:
   version: 0.4.24
   resolution: "babel-plugin-transform-react-remove-prop-types@npm:0.4.24"
   checksum: 2/4004ce6c87bd49223f996a4d0b98312083e7bd40d7cfb04711936001b31fd01502b7eea0b94c9116fb384668cdbe114e1866d79c25b72ad0d6cd2f32819c1094
-  languageName: node
-  linkType: hard
-
-"babel-preset-gatsby-package@npm:^0.4.4":
-  version: 0.4.4
-  resolution: "babel-preset-gatsby-package@npm:0.4.4"
-  dependencies:
-    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.10.1
-    "@babel/plugin-proposal-optional-chaining": ^7.10.1
-    "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-transform-runtime": ^7.10.1
-    "@babel/plugin-transform-typescript": ^7.10.1
-    "@babel/preset-env": ^7.10.2
-    "@babel/preset-flow": ^7.10.1
-    "@babel/preset-react": ^7.10.1
-    babel-plugin-dynamic-import-node: ^2.3.3
-    core-js: ^2.6.11
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 2/afe933d0a9289a303e6b04f15535532f9effa601af55a6fcb0e47a6b71dbb0d500b5dba1e6d327171f88b8990b65830c27256d1d6a6b630c6b175723b5addebf
   languageName: node
   linkType: hard
 
@@ -7795,7 +7550,6 @@ fsevents@~2.1.1:
     "@typescript-eslint/typescript-estree": ^2.21.0
     "@yarnpkg/pnpify": ^2.0.0-rc.18
     babel-plugin-dynamic-import-node: ^2.3.3
-    babel-preset-gatsby-package: ^0.4.4
     eslint: ^6.8.0
     fs-extra: ^8.1.0
     gatsby: ^2.19.18

--- a/yarn.lock
+++ b/yarn.lock
@@ -7374,6 +7374,7 @@ fsevents@~2.1.1:
     fs-extra: ^8.1.0
     gatsby: ^2.19.18
     lodash.mergewith: ^4.6.2
+    npm-run-all: ^4.1.5
     rimraf: ^3.0.2
     ts-node: ^8.6.2
     ts-transformer-keys: ^0.4.1
@@ -9623,6 +9624,18 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"load-json-file@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "load-json-file@npm:4.0.0"
+  dependencies:
+    graceful-fs: ^4.1.2
+    parse-json: ^4.0.0
+    pify: ^3.0.0
+    strip-bom: ^3.0.0
+  checksum: 2/692f33387be2439e920e394a70754499c22eabe567f55fee7c0a8994c050e27360c1b39c5375d214539ebb7d609d28e69f6bd6e3c070d30bc202c99289e27f96
+  languageName: node
+  linkType: hard
+
 "loader-fs-cache@npm:^1.0.0":
   version: 1.0.2
   resolution: "loader-fs-cache@npm:1.0.2"
@@ -10009,6 +10022,13 @@ fsevents@~2.1.1:
     errno: ^0.1.3
     readable-stream: ^2.0.1
   checksum: 2/deb916f33ca09215d6ad58db30854bbf36aaca86e018dcbbbdb7c6160661e8c0b9acdcc23c9931fc6dcd62f3dd5318a7ecab519e3688f7787d0833e5f48c0d0a
+  languageName: node
+  linkType: hard
+
+"memorystream@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "memorystream@npm:0.3.1"
+  checksum: 2/825bcc7d3eb8bd021a1b0f8c81e4d7a8dc2eced1f8bb79d41ec978547cf118146d6863f5e6134f02bb55ee5d963a8689793e6e82ce8eb989bac339ae782728bb
   languageName: node
   linkType: hard
 
@@ -10680,6 +10700,27 @@ fsevents@~2.1.1:
     npm-bundled: ^1.0.1
     npm-normalize-package-bin: ^1.0.1
   checksum: 2/34c4bbd47daccd64e5e432b435ec37339bd472900dccd2a8f003d5004b4fff67b8561aadbbedaa5a5effd1dab9126b89fb28355fef1f3e85ff60ecf6b21433d9
+  languageName: node
+  linkType: hard
+
+"npm-run-all@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "npm-run-all@npm:4.1.5"
+  dependencies:
+    ansi-styles: ^3.2.1
+    chalk: ^2.4.1
+    cross-spawn: ^6.0.5
+    memorystream: ^0.3.1
+    minimatch: ^3.0.4
+    pidtree: ^0.3.0
+    read-pkg: ^3.0.0
+    shell-quote: ^1.6.1
+    string.prototype.padend: ^3.0.0
+  bin:
+    npm-run-all: bin/npm-run-all/index.js
+    run-p: bin/run-p/index.js
+    run-s: bin/run-s/index.js
+  checksum: 2/ef1b5b5a5fe7864d2b45c13de6dbffacde956bfc265117e0d1c8b05ee34264d494e5e65474d46592228e3a00857eae58359782fe7889d73de0a8714e6f9c0e83
   languageName: node
   linkType: hard
 
@@ -11413,6 +11454,15 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"path-type@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "path-type@npm:3.0.0"
+  dependencies:
+    pify: ^3.0.0
+  checksum: 2/db700bfc22254b38d0c8378440ec8b7b869f5d0b946d02abd281bcc6ea456a573167a8a80dd8280848998bb9739c2009f80bcf0dbf5c9d75ab18650e07fb893f
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -11451,6 +11501,15 @@ fsevents@~2.1.1:
   version: 2.2.1
   resolution: "picomatch@npm:2.2.1"
   checksum: 2/c926fe6cb118643bbd4eb44125afbfa02fcd3f6ff3ba85db201874678a46ab2dad589c8db654474cc131df356af36a6afd4fb3c8878ca26bae5190c232b838a5
+  languageName: node
+  linkType: hard
+
+"pidtree@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "pidtree@npm:0.3.1"
+  bin:
+    pidtree: bin/pidtree.js
+  checksum: 2/8a48f063cb60e188bc94c307a309d309e20e9a3c3ca3537a035baf66dba2315f7b175d3a13a3b816db349dad270e347877b5aeae6d763360be650b3d1b1ca9b3
   languageName: node
   linkType: hard
 
@@ -12430,6 +12489,17 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"read-pkg@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "read-pkg@npm:3.0.0"
+  dependencies:
+    load-json-file: ^4.0.0
+    normalize-package-data: ^2.3.2
+    path-type: ^3.0.0
+  checksum: 2/8cc577b41ddd70a0037d6c0414acfab8db3a25a30c7854decf3d613f1f4240c8a47e20fddbd82724e02d4eb5a0c489e2621b4a5bb3558e09ce81f53306d1b850
+  languageName: node
+  linkType: hard
+
 "read@npm:^1.0.7":
   version: 1.0.7
   resolution: "read@npm:1.0.7"
@@ -13327,6 +13397,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"shell-quote@npm:^1.6.1":
+  version: 1.7.2
+  resolution: "shell-quote@npm:1.7.2"
+  checksum: 2/3b3d06814ca464cde8594c27bdd57a1f4c06b26ad2988b08b5819f97ac1edfd7cb7313fda1c909da33211972c72c5a7906b7da2b62078109f9d3274d3f404fa9
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.2":
   version: 1.0.2
   resolution: "side-channel@npm:1.0.2"
@@ -13894,6 +13971,16 @@ fsevents@~2.1.1:
     regexp.prototype.flags: ^1.3.0
     side-channel: ^1.0.2
   checksum: 2/0ca2937d28a80ad10b3173ff8e2f4ac0aa101b127b8256c3a6e749b7ab619e250208848c7fd9a740760df7e94c5b225fc6d0830e0f9d0e1ef615f3149cd194a9
+  languageName: node
+  linkType: hard
+
+"string.prototype.padend@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "string.prototype.padend@npm:3.1.0"
+  dependencies:
+    define-properties: ^1.1.3
+    es-abstract: ^1.17.0-next.1
+  checksum: 2/a64b67709ce758d0c7200933ec6d238c8be022aabcf1e17e1a13d6dbfa59a180597cadc1c7b7ef7408343367ea286bd39ca3c61de88ab6d2e4cabed90af626e4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7560,7 +7560,7 @@ fsevents@~2.1.1:
     ts-transformer-keys: ^0.4.1
     ttypescript: ^1.5.10
     type-fest: ^0.12.0
-    typescript: 3.8.3
+    typescript: 3.9.6
   peerDependencies:
     "@babel/core": ^7.0.0
     "@babel/runtime": ^7.8.7
@@ -14785,23 +14785,23 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-typescript@3.8.3:
-  version: 3.8.3
-  resolution: "typescript@npm:3.8.3"
+typescript@3.9.6:
+  version: 3.9.6
+  resolution: "typescript@npm:3.9.6"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 2/519b11576247fe3570d89a2aa757d8f666aafc0cb9465a6cdd4df09c1dc6bf7285f0c6008d2ac7a55ea26457e767aaab819f58439d80af2cce1d9805b2be1034
+  checksum: 2/75d8e3610ca435b0feaa3eb714ef3aa9060ec72621da3c62c45ceee1d8d0ddcbd8ff2a816de2d24ab28dcd2249953edb640d34595d59e491656156da4c2903fc
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@3.8.3#builtin<compat/typescript>":
-  version: 3.8.3
-  resolution: "typescript@patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=273569"
+"typescript@patch:typescript@3.9.6#builtin<compat/typescript>":
+  version: 3.9.6
+  resolution: "typescript@patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=273569"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 2/345573d9ee784f75c4facb98e838d28fe1376648abd627e3bca256237965940f331bf0ed502de6068f0cca9111eac675ca26d901202547068d52d66685e42be2
+  checksum: 2/849414205dad35867d0601dcc2253d605ad779f692c102ba5e746487af83363e106de7f3408a2bbb2292fa43fb06674543f3a2df81336b04219eb0f5d1d20f39
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR implements a new API: `includePlugins`.  With this function, you can resolve local/vendor plugins before they are given to Gatsby.  Resolving plugins this way will also transpile them, if they are Typescript, so that they are ready for consumption.

The type utility used for defining plugin option types, `IMergePluginOptions`, has been removed.  It is now replaced by `IGatsbyPluginDef`, which can be used in conjunction with `includePlugins`, to strongly type your plugin options.

The function export from `gatsby-node` and `gatsby-config` will no longer accept a second generic type parameter.

Use `includePlugins()` from now on to type your plugins.

---

Closes #12 