### PR TITLE
Enable all extensions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type { TSConfigSetupOptions, PropertyBag } from './types';
 
 type GeneratedGatsbyConfig = Pick<GatsbyConfig, 'plugins'>;
 interface IGenerateConfig {
-    (args: TSConfigSetupOptions, props: PropertyBag): GeneratedGatsbyConfig;
+    (args: TSConfigSetupOptions, props?: PropertyBag): GeneratedGatsbyConfig;
 }
 
 export const generateConfig: IGenerateConfig = (options, props = {}) => {

--- a/src/utils/preset.ts
+++ b/src/utils/preset.ts
@@ -51,7 +51,10 @@ const preset = () => {
             },
             {
                 test: [`**/*.tsx`],
-                presets: [[r(`@babel/preset-typescript`), { isTSX: true }]],
+                presets: [[r(`@babel/preset-typescript`), {
+                    isTSX: true,
+                    allExtensions: true,
+                }]],
             },
         ],
     };


### PR DESCRIPTION
Adds `allExtensions: true` to the `*.tsx` babel preset