### PR TITLE
use parentDir field for plugin resolution

### DIFF
--- a/src/gatsby/gatsby-config.ts
+++ b/src/gatsby/gatsby-config.ts
@@ -99,8 +99,9 @@ export default (args = {} as ITSConfigPluginOptions): GatsbyConfig => {
         ...gatsbyConfig,
         plugins: [
             ...OptionsHandler.plugins.map((plugin) => ({
-                resolve: plugin.path,
+                resolve: plugin.name,
                 options: plugin.options,
+                parentDir: projectRoot,
             })),
         ],
     };


### PR DESCRIPTION
use `parentDir` field on plugin metadata instead of resolving `resolve` property to fully-qualified path.

Depends on https://github.com/gatsbyjs/gatsby/pull/28523

Closes #26