### PR TITLE
add `/package.json` to plugin path

### DIFF
--- a/src/gatsby/gatsby-config.ts
+++ b/src/gatsby/gatsby-config.ts
@@ -99,7 +99,7 @@ export default (args = {} as ITSConfigPluginOptions): GatsbyConfig => {
         ...gatsbyConfig,
         plugins: [
             ...OptionsHandler.plugins.map((plugin) => ({
-                resolve: plugin.path,
+                resolve: `${plugin.path}/package.json`,
                 options: plugin.options,
             })),
         ],


### PR DESCRIPTION
Appends `/package.json` to plugin paths, to make Gatsby's plugin root resolution more definitive.

Closes: #23 