### PR TITLE
use resolveFilePath to get requirePath

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gatsby-plugin-ts-config",
-	"version": "2.0.1",
+	"version": "2.0.2-rc.1",
 	"description": "Configure Gatsby to use Typescript configuration files",
 	"main": "./index.js",
 	"types": "./dist/index",

--- a/src/lib/transpiler.ts
+++ b/src/lib/transpiler.ts
@@ -4,6 +4,7 @@ import omit from "lodash/omit";
 import babelRegister from "@babel/register";
 
 import { Module, preferDefault } from "@util/node";
+import { resolveFilePath } from "@util/fs-tools";
 import { getImportHandler } from "./options/imports";
 import { getRegisterOptions } from "./options/register";
 
@@ -99,12 +100,18 @@ export const getTranspiler = (
             if (typeof init === "function") {
                 return omit(init(), ["__esModule"]) as PluginModule<TApiType>;
             } else {
-                const requirePath = require.resolve(
-                    path.resolve(
-                        projectRoot,
-                        init,
-                    )
+                const requirePath = resolveFilePath(
+                    projectRoot,
+                    path.resolve(projectRoot, init)
                 );
+
+                if (!requirePath) {
+                    throw new Error([
+                        `Unable to resolve module '${init}' from`,
+                        `Path: ${projectRoot}`
+                    ].join("\n"))
+                }
+
                 const mod = require(requirePath);
 
                 const resolveFn: TSConfigFn<any> = (opts, props) => {

--- a/src/util/fs-tools.ts
+++ b/src/util/fs-tools.ts
@@ -15,7 +15,7 @@ export const getFile: typeof fileExists = (fpath) => (
 );
 
 const moduleResolver = resolve.create.sync({
-    extensions: [".js", ".ts"],
+    extensions: [".ts", ".js"],
 });
 
 export const resolveFilePath = (startDir: string, moduleName: string): false | string => {


### PR DESCRIPTION
Use the `resolveFilePath` utility (`enhanced-resolve`) in order to get the `requirePath` used by the transpiler.

This should allow `gatsby.js` and `gatsby.ts` to live side-by-side, and not require an extension in the api calls.

--- 

Closes #40 