### PR TITLE
disable error thrown on dupe plugin linking

### DIFF
--- a/src/lib/project/transpiler/import-handler.ts
+++ b/src/lib/project/transpiler/import-handler.ts
@@ -1,4 +1,4 @@
-import { PluginError } from "@util/output";
+// import { PluginError } from "@util/output";
 import { popArray } from "@util/objects";
 import type { Project } from "@lib/project";
 import type {

--- a/src/lib/project/transpiler/import-handler.ts
+++ b/src/lib/project/transpiler/import-handler.ts
@@ -53,12 +53,12 @@ class ImportHandlerImpl {
             rootProject.plugins = {}
         );
 
-        if (pluginLinks.hasOwnProperty(pluginName)) {
-            throw new PluginError([
-                `Attempting to link plugin ${pluginName} to project ${projectName} failed.`,
-                `Plugin ${pluginName} has already been linked!`,
-            ].join("\n"));
-        }
+        // if (pluginLinks.hasOwnProperty(pluginName)) {
+        //     throw new PluginError([
+        //         `Attempting to link plugin ${pluginName} to project ${projectName} failed.`,
+        //         `Plugin ${pluginName} has already been linked!`,
+        //     ].join("\n"));
+        // }
 
         pluginLinks[pluginName] = pluginProject;
     }


### PR DESCRIPTION
There can be (and frequently is) multiple plugins of the same name.  Can't throw an error on linking the same plugin to a project.

Fixes #48