### PR TITLE
chore: update peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,102 +1,102 @@
 {
-	"name": "gatsby-plugin-ts-config",
-	"version": "2.1.3",
-	"description": "Configure Gatsby to use Typescript configuration files",
-	"main": "./index.js",
-	"types": "./dist/index",
-	"author": "Jeremy Albright",
-	"license": "MIT",
-	"keywords": [
-		"gatsby-plugin",
-		"gatsby-config",
-		"gatsby",
-		"typescript"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Js-Brecht/gatsby-plugin-ts-config"
-	},
-	"homepage": "https://github.com/Js-Brecht/gatsby-plugin-ts-config",
-	"bugs": {
-		"url": "https://github.com/Js-Brecht/gatsby-plugin-ts-config/issues"
-	},
-	"files": [
-		"dist",
-		"index.js",
-		"README.md",
-		"LICENSE"
-	],
-	"scripts": {
-		"purge": "rimraf node_modules && yarn clean",
-		"clean": "rimraf './dist/*'",
-		"build": "run-s clean build:prod",
-		"build:prod": "ttsc -p tsconfig.build.json",
-		"build:dev": "ttsc --sourceMap -p tsconfig.build.json",
-		"watch": "run-s clean \"build:prod -- -w\"",
-		"watch:dev": "run-s clean \"build:dev -- -w\"",
-		"lint": "eslint -c .eslintrc.js .",
-		"lint:fix": "eslint -c .eslintrc.js --fix ."
-	},
-	"peerDependencies": {
-		"gatsby": "~2.x.x || ~3.x.x",
-		"typescript": "~4.x.x"
-	},
-	"peerDependenciesMeta": {
-		"@babel/runtime": {
-			"optional": true
-		},
-		"eslint": {
-			"optional": true
-		},
-		"typescript": {
-			"optional": true
-		}
-	},
-	"dependencies": {
-		"@babel/core": "^7.9.0",
-		"@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
-		"@babel/plugin-proposal-optional-chaining": "^7.10.3",
-		"@babel/plugin-syntax-dynamic-import": "^7.8.3",
-		"@babel/plugin-transform-runtime": "^7.10.3",
-		"@babel/plugin-transform-typescript": "^7.10.3",
-		"@babel/preset-env": "^7.10.3",
-		"@babel/preset-flow": "^7.10.1",
-		"@babel/preset-react": "^7.10.1",
-		"@babel/preset-typescript": "^7.8.3",
-		"@babel/register": "^7.8.6",
-		"@babel/runtime": "^7.8.7",
-		"babel-plugin-dynamic-import-node": "^2.3.3",
-		"callsites": "^3.1.0",
-		"enhanced-resolve": "^5.8.0",
-		"find-up": "^5.0.0",
-		"fs-extra": "^8.1.0",
-		"lodash": "^4.17.21",
-		"serialize-error": "^8.1.0",
-		"ts-node": "^9.0.0",
-		"tslog": "^3.2.0",
-		"type-fest": "^0.12.0"
-	},
-	"devDependencies": {
-		"@babel/core": "^7.8.6",
-		"@types/babel__core": "^7.1.6",
-		"@types/fs-extra": "^8.1.0",
-		"@types/lodash": "^4.14.172",
-		"@types/node": "^13.7.2",
-		"@types/webpack": "^4.41.6",
-		"@yarnpkg/pnpify": "^2.4.0",
-		"@yarnpkg/sdks": "^2.4.1-rc.4",
-		"@zerollup/ts-transform-paths": "^1.7.18",
-		"eslint": "npm:@jtechsvcs/eslint@^1.0.5",
-		"gatsby": "^3.11.1",
-		"npm-run-all": "^4.1.5",
-		"rimraf": "^3.0.2",
-		"ts-transformer-keys": "^0.4.1",
-		"ttypescript": "^1.5.10",
-		"typescript": "4.4.2"
-	},
-	"dependenciesMeta": {
-		"@jtechsvcs/eslint@1.0.5": {
-			"unplugged": true
-		}
-	}
+  "name": "gatsby-plugin-ts-config",
+  "version": "2.1.3",
+  "description": "Configure Gatsby to use Typescript configuration files",
+  "main": "./index.js",
+  "types": "./dist/index",
+  "author": "Jeremy Albright",
+  "license": "MIT",
+  "keywords": [
+    "gatsby-plugin",
+    "gatsby-config",
+    "gatsby",
+    "typescript"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Js-Brecht/gatsby-plugin-ts-config"
+  },
+  "homepage": "https://github.com/Js-Brecht/gatsby-plugin-ts-config",
+  "bugs": {
+    "url": "https://github.com/Js-Brecht/gatsby-plugin-ts-config/issues"
+  },
+  "files": [
+    "dist",
+    "index.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "purge": "rimraf node_modules && yarn clean",
+    "clean": "rimraf './dist/*'",
+    "build": "run-s clean build:prod",
+    "build:prod": "ttsc -p tsconfig.build.json",
+    "build:dev": "ttsc --sourceMap -p tsconfig.build.json",
+    "watch": "run-s clean \"build:prod -- -w\"",
+    "watch:dev": "run-s clean \"build:dev -- -w\"",
+    "lint": "eslint -c .eslintrc.js .",
+    "lint:fix": "eslint -c .eslintrc.js --fix ."
+  },
+  "peerDependencies": {
+    "gatsby": "~2.x.x || ~3.x.x || ~4.x.x",
+    "typescript": "~4.x.x"
+  },
+  "peerDependenciesMeta": {
+    "@babel/runtime": {
+      "optional": true
+    },
+    "eslint": {
+      "optional": true
+    },
+    "typescript": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@babel/core": "^7.9.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
+    "@babel/plugin-proposal-optional-chaining": "^7.10.3",
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.10.3",
+    "@babel/plugin-transform-typescript": "^7.10.3",
+    "@babel/preset-env": "^7.10.3",
+    "@babel/preset-flow": "^7.10.1",
+    "@babel/preset-react": "^7.10.1",
+    "@babel/preset-typescript": "^7.8.3",
+    "@babel/register": "^7.8.6",
+    "@babel/runtime": "^7.8.7",
+    "babel-plugin-dynamic-import-node": "^2.3.3",
+    "callsites": "^3.1.0",
+    "enhanced-resolve": "^5.8.0",
+    "find-up": "^5.0.0",
+    "fs-extra": "^8.1.0",
+    "lodash": "^4.17.21",
+    "serialize-error": "^8.1.0",
+    "ts-node": "^9.0.0",
+    "tslog": "^3.2.0",
+    "type-fest": "^0.12.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.8.6",
+    "@types/babel__core": "^7.1.6",
+    "@types/fs-extra": "^8.1.0",
+    "@types/lodash": "^4.14.172",
+    "@types/node": "^13.7.2",
+    "@types/webpack": "^4.41.6",
+    "@yarnpkg/pnpify": "^2.4.0",
+    "@yarnpkg/sdks": "^2.4.1-rc.4",
+    "@zerollup/ts-transform-paths": "^1.7.18",
+    "eslint": "npm:@jtechsvcs/eslint@^1.0.5",
+    "gatsby": "^3.11.1",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^3.0.2",
+    "ts-transformer-keys": "^0.4.1",
+    "ttypescript": "^1.5.10",
+    "typescript": "4.4.2"
+  },
+  "dependenciesMeta": {
+    "@jtechsvcs/eslint@1.0.5": {
+      "unplugged": true
+    }
+  }
 }


### PR DESCRIPTION
This updates the `peerDependencies` and also includes `gatsby` versions `4.x.x`. I'm running the latest version of `gatsby` for quite some time and haven't discovered any incompatibilities with this plugin.

Fixes #55